### PR TITLE
ensures metrics-server is installed in the correct ns

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ setup-observability:
 	kubectl apply -f ./monitoring/istio-addons/grafana-vs.yaml
 	helm upgrade --install loki grafana/loki-stack -n monitoring --create-namespace
 	helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/  && helm repo update
-	helm upgrade --install metrics-server metrics-server/metrics-server --values ./monitoring/chart-values/metric-server.yaml
+	helm upgrade --install metrics-server metrics-server/metrics-server --values ./monitoring/chart-values/metric-server.yaml -n monitoring --create-namespace
 
 setup-apm:
 	helm repo add signoz https://charts.signoz.io && helm repo updates


### PR DESCRIPTION
fixes following errors, when trying to re-install:
```
Error: Unable to continue with install: APIService "v1beta1.metrics.k8s.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "monitoring": current value is "prod-robot-shop"
```
```
Error: Unable to continue with install: RoleBinding "metrics-server-auth-reader" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "monitoring": current value is "prod-robot-shop"
```

Essentially ownership metadata for helm defaulted to app namespace when installed without `-n monitoring` hence successive reinstall workflows were getting botched up.