### PR TITLE
monitoring/kue-prome-stack/grafana - add plugin: novatec-sdg-panel

### DIFF
--- a/monitoring/chart-values/prometheus-values.yaml
+++ b/monitoring/chart-values/prometheus-values.yaml
@@ -96,6 +96,8 @@ grafana:
       effect: NoSchedule 
   nodeSelector:
     workload: o11y
+  plugins:
+    - novatec-sdg-panel
 
   sidecar:
     dashboards:


### PR DESCRIPTION
Adds demo service dependency graph panel.
Source: https://grafana.com/grafana/plugins/novatec-sdg-panel/
