### PR TITLE
Otel migration

### DIFF
--- a/OTEL_MIGRATION.md
+++ b/OTEL_MIGRATION.md
@@ -1,202 +1,94 @@
-# OpenTelemetry Migration — Demo Guide
-
-This document covers the full OTel migration scope added to `sre-stack`:
-a two-script demo that shows the observability stack **before** and **after** migrating
-to OpenTelemetry Collector, with Robot Shop + HotROD running on a local k3d cluster.
-
----
+# OpenTelemetry Migration
 
 ## Scope
 
-| Signal | Before | After |
-|--------|--------|-------|
-| **Logs** | Promtail → Loki 2.x (no trace correlation) | filelog (OTel agent) → OTel gateway → Loki 3.x (OTLP, structured metadata, trace\_id on every log) |
-| **Metrics** | Prometheus scraping only (no host/kubelet metrics) | hostmetrics + kubeletstats (OTel agent) + k8s\_cluster (gateway) → Prometheus remote\_write |
-| **Traces** | Istio ingress hops only (1–2 spans, no app-level detail) | App OTLP → OTel agent → gateway → Tempo (full span tree: frontend / DB / Redis calls) |
-| **Prometheus scraping** | ServiceMonitor-based | OTel gateway prometheusreceiver with kubernetes\_sd\_configs |
-| **K8s enrichment** | None | k8sattributes processor stamps `k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name` + all pod labels on every signal |
+The goal of this migration is to replace the fragmented, signal-siloed observability stack with a unified OpenTelemetry pipeline that gives full cross-signal correlation — logs, metrics, and traces enriched with the same Kubernetes context on every record.
 
----
+### Problems with the existing stack
 
-## Architecture
-
-### Before
-
-```
-Robot Shop pods ──► Promtail ──────────────────► Loki 2.x
-HotROD          ──► Jaeger endpoint (Istio)  ──► Tempo  (1-2 spans)
-All pods        ──► Prometheus scraping       ──► Prometheus
-                    (no host/kubelet metrics)
-```
-
-### After
-
-```
-                    ┌─────────────────────────────────────────────┐
-                    │  OTel Agent DaemonSet (one pod per node)    │
-Robot Shop pods ───►│  filelog | hostmetrics | kubeletstats        │
-HotROD          ───►│  k8sattributes processor                    │
-                    └──────────────┬──────────────────────────────┘
-                                   │ OTLP gRPC
-                                   ▼
-                    ┌─────────────────────────────────────────────┐
-                    │  OTel Gateway Deployment (o11y nodes)       │
-                    │  k8sobjects | k8s_cluster | prometheus rcvr │
-                    │  k8sattributes + resource processors        │
-                    └───┬──────────────┬────────────┬────────────┘
-                        │              │            │
-                        ▼              ▼            ▼
-                     Tempo          Prometheus   Loki 3.x
-                  (full traces)  (remote_write) (OTLP ingest)
-```
-
----
-
-## New Files
-
-| File | Purpose |
+| Area | Problem |
 |------|---------|
-| `demo-1-before.sh` | Builds the "before" state: k3d cluster + Istio + Prometheus + Loki 2.x + Tempo + Robot Shop + HotROD |
-| `demo-2-migrate-otel.sh` | Runs the full 8-step OTel migration live |
-| `app/robot-shop/robot-shop-local-values.yaml` | Helm overrides for the 4-node k3d cluster (single app node, no persistent node) |
-| `monitoring/chart-values/otel-agent-values.yaml` | OTel Agent DaemonSet — filelog, hostmetrics, kubeletstats |
-| `monitoring/chart-values/otel-gateway-values.yaml` | OTel Gateway Deployment — OTLP fan-out to Tempo + Prometheus + Loki |
-| `monitoring/chart-values/otel-gateway-prom-scrape-values.yaml` | Gateway with added prometheusreceiver (kubernetes\_sd\_configs) |
-| `monitoring/chart-values/loki-v3-values.yaml` | Loki 3.x (grafana/loki 7.0.0) — OTLP ingest, tsdb schema, allow\_structured\_metadata |
+| **Logs** | Promtail ships logs to Loki 2.x with no `trace_id`. You cannot click from a log line to the trace that caused it. |
+| **Metrics** | Prometheus only scrapes what has a ServiceMonitor. Host CPU, memory, disk (node-level) and pod resource usage (kubelet) are invisible. |
+| **Traces** | HotROD sends to a Jaeger endpoint intercepted by Istio. Only 1–2 ingress-hop spans appear in Tempo — no Redis calls, no DB calls, no root-cause visibility. |
+| **K8s context** | No signal carries `k8s.pod.name`, `k8s.namespace.name`, or `k8s.node.name`. Cross-signal correlation requires manual label matching. |
+| **Prometheus scraping** | No path from OTel to Prometheus. Two separate scrape pipelines with no shared enrichment. |
 
 ---
 
-## Prerequisites
+## What was built
 
-- Docker Desktop (≥ 8 GB RAM allocated)
-- k3d ≥ 5.6
-- kubectl
-- helm ≥ 3.12
-- istioctl (for `make setup-istio`)
-- Ports 8080 and 18080 free on localhost
+### Two-tier OTel Collector
+
+The migration introduces a two-tier collector architecture:
+
+```
+[OTel Agent DaemonSet]   — one pod per node, node-local collection
+        │
+        │  OTLP gRPC
+        ▼
+[OTel Gateway Deployment] — cluster-wide aggregation and fan-out
+        │
+        ├──► Loki 3.x      (logs via OTLP HTTP)
+        ├──► Prometheus     (metrics via remote_write)
+        └──► Tempo          (traces via OTLP gRPC)
+```
+
+**Why two tiers?** The agent only needs host-level RBAC. The gateway holds all exporter config, retry logic, and enrichment in one place and can be scaled independently. This also means rotating an exporter endpoint (e.g., pointing to a different Loki) requires only a gateway change, not a DaemonSet rollout.
 
 ---
 
-## Running the Demo
+## Files and what they solve
 
-### Step 1 — Build the "before" state
+### `monitoring/chart-values/otel-agent-values.yaml`
 
-```bash
-./demo-1-before.sh
-```
+Deploys the OTel Collector as a DaemonSet on every node (including tainted o11y nodes via `tolerations: [{operator: Exists}]`).
 
-This script:
-1. Deletes any existing `sre-stack-local` k3d cluster and creates a fresh 4-node one
-2. Labels nodes: `agent-0/1` → `workload=o11y` (tainted), `agent-2` → `workload=app`
-3. Installs: kube-prometheus-stack, Loki 2.x + Promtail, Tempo, Istio
-4. Deploys Robot Shop (with Istio sidecar injection) and HotROD
-5. Starts port-forwards: `localhost:8080` (Grafana + Robot Shop via Istio) and `localhost:18080` (HotROD)
-6. Sends 30 warmup requests to populate Istio metrics
+**Receivers enabled:**
 
-**Access:**
-- Grafana: `http://localhost:8080/grafana` (admin / prom-operator)
-- Robot Shop: `http://localhost:8080`
-- HotROD: `http://localhost:18080`
+| Receiver | Solves |
+|----------|--------|
+| `filelog` | Replaces Promtail. Reads CRI-format logs from `/var/log/pods/**`, parses them, and forwards via OTLP. Logs now carry `trace_id` as structured metadata. |
+| `hostmetrics` | Collects CPU, memory, disk, network per node. Previously invisible in Prometheus. |
+| `kubeletstats` | Collects per-pod and per-container resource usage from the kubelet API. Previously invisible. Note: `insecure_skip_verify: true` required because k3d kubelet certs have no IP SANs. |
 
-**What to show (before — limitations):**
+The `k8sattributes` preset stamps every log, metric, and trace with:
+- `k8s.pod.name`
+- `k8s.namespace.name`
+- `k8s.node.name`
+- All pod labels (via `extractAllPodLabels: true`)
 
-| Check | Result |
-|-------|--------|
-| Application Dashboard → Service Map | ✅ Istio request rates visible |
-| Explore → Prometheus → `system_cpu_time_seconds_total` | ❌ No data — no host metrics |
-| Explore → Prometheus → `k8s_deployment_desired` | ❌ No data — no cluster-state metrics |
-| Explore → Tempo → Search | ❌ 1–2 Istio ingress spans only; no Redis/DB call visibility |
-| Explore → Loki → `{namespace="robot-shop"}` | ❌ Logs exist but no `trace_id` field |
+This is the single change that enables cross-signal correlation without any application code changes.
 
 ---
 
-### Step 2 — Run the OTel migration
+### `monitoring/chart-values/otel-gateway-values.yaml`
 
-```bash
-./demo-2-migrate-otel.sh
+Deploys the OTel Collector as a Deployment on the o11y nodes. Receives OTLP from all agents and fans out to three backends.
+
+**Receivers enabled:**
+
+| Receiver | Solves |
+|----------|--------|
+| `otlp` | Accepts signals from all agent pods |
+| `k8sobjects` | Ingests Kubernetes events (CrashLoopBackOff, OOMKilled, scheduling failures) as log records → Loki. Previously these were only visible in `kubectl describe`. |
+| `k8s_cluster` | Emits cluster-state metrics: deployment desired/ready replicas, pod phases, node conditions → Prometheus. Replaces kube-state-metrics for this use case. |
+
+**Key processors:**
+
+`resource/app-label` — synthesises an `app` resource attribute from pod labels so Loki stream labels match existing dashboard queries:
+```yaml
+resource/app-label:
+  attributes:
+    - action: insert
+      key: app
+      from_attribute: k8s.pod.labels.service   # Robot Shop uses service: web
+    - action: upsert
+      key: app
+      from_attribute: k8s.pod.labels.app        # HotROD and others use app: hotrod
 ```
 
-Eight steps, each idempotent:
-
-| Step | What happens |
-|------|-------------|
-| 1 | Helm repo setup (open-telemetry, grafana, prometheus-community) |
-| 2 | Enable Prometheus `remote_write` receiver |
-| 3 | Uninstall loki-stack (Loki 2.x + Promtail) → install grafana/loki 7.0.0 (Loki 3.x, OTLP) |
-| 4 | Deploy OTel Gateway — receives OTLP from agents, fans out to Tempo / Prometheus / Loki |
-| 5 | Deploy OTel Agent DaemonSet — filelog + hostmetrics + kubeletstats on every node |
-| 6 | Rewire HotROD: remove `JAEGER_ENDPOINT`, set `OTEL_EXPORTER_OTLP_ENDPOINT=gateway:4318` |
-| 7 | Generate traffic: 40 Robot Shop requests + 20 HotROD dispatches |
-| 8 | Upgrade gateway to add prometheusreceiver (kubernetes\_sd\_configs scraping) |
-
----
-
-## What to Validate After Migration
-
-### Logs (Loki 3.x)
-
-```
-Explore → Loki → {k8s_namespace_name="robot-shop"}
-```
-- Every log line has `k8s.pod.name`, `k8s.namespace.name`, `trace_id` as structured metadata
-- `trace_id` is clickable → jumps to the exact trace in Tempo
-
-### Traces (Tempo)
-
-```
-Explore → Tempo → Search → Service: hotrod
-```
-- Each dispatch shows 5+ spans: `frontend` → `customer` → `driver` → `route` → `redis`
-- Click any span → `k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name` visible
-- Click "Logs for this span" → correlated Loki logs for that pod/time window
-
-### Metrics (Prometheus)
-
-```
-Explore → Prometheus → system_cpu_time_seconds_total   # host metrics (OTel agent)
-Explore → Prometheus → k8s_deployment_desired          # cluster state (OTel gateway)
-Explore → Prometheus → container_cpu_usage_seconds_total # kubeletstats
-Explore → Prometheus → up{job="grafana"}               # OTel Prometheus scraping
-```
-
-### Application Dashboard
-
-- Service Map still populated (Istio `istio_requests_total` metrics continue)
-- Service Error Log panels now query Loki by pod name — no "No data"
-
----
-
-## Key Design Decisions
-
-### Two-tier collector architecture
-
-The **agent** runs as a DaemonSet with `tolerations: [{operator: Exists}]` so it collects
-from every node including tainted o11y nodes. It only ships `filelog`, `hostmetrics`,
-and `kubeletstats` — node-local signals. Everything is forwarded via OTLP gRPC to the
-**gateway** Deployment which runs on the o11y nodes and handles enrichment and fan-out.
-
-This avoids giving every agent pod the RBAC rights needed to talk to Loki/Prometheus/Tempo,
-keeps exporter retry logic in one place, and lets you scale the gateway independently.
-
-### k8sattributes processor
-
-Both agent and gateway run `k8sattributes` with `extractAllPodLabels: true`. This stamps
-`k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name`, and every pod label on every span,
-metric, and log record. This is the single key that enables cross-signal correlation in Grafana
-without any application-side instrumentation changes.
-
-### Loki 3.x + OTLP ingest
-
-`loki-stack` (Loki 2.9) has no OTLP endpoint. `grafana/loki 7.0.0` (Loki 3.6.7) adds
-`/otlp/v1/logs` and `allow_structured_metadata: true`, which stores OTel attributes
-(including `trace_id`) alongside log lines as indexed structured metadata rather than
-requiring label cardinality to blow up.
-
-### `resource/loki-labels` processor
-
-Loki OTLP ingest won't index resource attributes as stream labels unless you tell it which
-ones to use. The `resource/loki-labels` processor inserts a `loki.resource.labels` hint:
-
+`resource/loki-labels` — tells Loki 3.x which resource attributes to index as stream labels (keeps cardinality low while making the labels dashboards need available):
 ```yaml
 resource/loki-labels:
   attributes:
@@ -205,30 +97,81 @@ resource/loki-labels:
       value: service.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,app
 ```
 
-This keeps stream label cardinality low while making the labels the dashboard queries need
-available for filtering.
+---
 
-### Local cluster overrides (`robot-shop-local-values.yaml`)
+### `monitoring/chart-values/loki-v3-values.yaml`
 
-The upstream Robot Shop chart targets a multi-node EKS cluster with separate persistent
-and app node groups. For the 4-node k3d demo cluster:
+Replaces `loki-stack` (Loki 2.9, no OTLP) with `grafana/loki 7.0.0` (Loki 3.6.7).
 
-- All `workload=persistent` nodeSelectors are redirected to `workload=app`
-- All replica counts reduced to 1 (avoids required podAntiAffinity on a single app node)
-- `affinity: null` (not `{}`) — Helm merges maps, so an empty map leaves base affinity
-  unchanged; `null` explicitly deletes the key
+| Change | Why |
+|--------|-----|
+| OTLP ingest at `/otlp/v1/logs` | OTel gateway pushes logs directly — no Promtail needed |
+| `allow_structured_metadata: true` | Stores OTel attributes (`trace_id`, `k8s.pod.name`, etc.) alongside log lines as queryable structured metadata without blowing up stream label cardinality |
+| tsdb/v13 schema | Required for Loki 3.x |
 
 ---
 
-## Cluster Node Layout
+### `monitoring/chart-values/otel-gateway-prom-scrape-values.yaml`
+
+Extends the gateway with a `prometheusreceiver` using `kubernetes_sd_configs` (endpoint discovery). This makes the OTel gateway responsible for Prometheus scraping, replacing direct ServiceMonitor-based scraping for a known target set.
+
+Scrape targets: Grafana (`/grafana/metrics`) and Prometheus self-metrics (`/metrics`). Results are pushed to Prometheus via `prometheusremotewrite` — the same exporter used for all other metrics, so they carry the same k8s enrichment.
+
+Additional RBAC added: the gateway's ClusterRole gets `get/list/watch` on `endpoints` and `services`, which `kubernetes_sd_configs` (role: endpoints) requires.
+
+---
+
+### `monitoring/dashboards/application.yaml`
+
+Updated the Service Error Log panels to use Loki stream labels that OTel actually emits. The original queries used `{app="web"}` (Promtail-style label). Robot Shop pods carry `service: web` (not `app`), so after migration these panels showed "No data".
+
+Fix: queries now use `k8s_namespace_name` + `k8s_pod_name` regex, which are guaranteed stream labels set by `resource/loki-labels`:
 
 ```
-k3d-sre-stack-local-server-0    control-plane
-k3d-sre-stack-local-agent-0     workload=o11y  (taint: o11y=true:NoSchedule)
-k3d-sre-stack-local-agent-1     workload=o11y  (taint: o11y=true:NoSchedule)
-k3d-sre-stack-local-agent-2     workload=app
+Before: {app="web"} |~ `(?i)error`
+After:  {k8s_namespace_name="robot-shop", k8s_pod_name=~"web-.*"} |~ `(?i)error`
 ```
 
-OTel agents run on all 4 nodes (toleration: `Exists`).
-OTel gateway, Loki, Prometheus, Tempo, Grafana run on agent-0/1 (o11y nodes).
-Robot Shop and HotROD run on agent-2 (app node).
+---
+
+### `app/robot-shop/robot-shop-local-values.yaml`
+
+The upstream Robot Shop chart targets a multi-node EKS cluster with separate `workload=persistent` and `workload=app` node pools. The local k3d demo cluster has only one app node. This override file:
+
+- Redirects all `workload=persistent` nodeSelectors to `workload=app` (MySQL, MongoDB, Redis, RabbitMQ)
+- Reduces all replicas to 1 (avoids required podAntiAffinity deadlock on a single node)
+- Uses `affinity: null` (not `affinity: {}`) — Helm merges maps, so an empty map leaves the base chart's podAntiAffinity unchanged; `null` explicitly removes the key
+
+---
+
+## What changed in each signal after migration
+
+### Logs
+- Promtail → OTel filelog receiver
+- Loki 2.x → Loki 3.x with OTLP ingest
+- Every log line now carries `trace_id`, `k8s.pod.name`, `k8s.namespace.name` as structured metadata
+- Kubernetes events (CrashLoopBackOff, OOMKilled) now flow into Loki as log records
+
+### Metrics
+- `system_cpu_time_seconds_total` — host CPU per node (was missing)
+- `container_cpu_usage_seconds_total` — per-pod usage from kubelet (was missing)
+- `k8s_deployment_desired` / `k8s_deployment_ready` — cluster state (was missing)
+- All metrics carry `k8s.namespace.name`, `k8s.pod.name` etc. via `resource_to_telemetry_conversion`
+
+### Traces
+- HotROD previously sent to `JAEGER_ENDPOINT` (Istio-intercepted, 1–2 spans)
+- Now sends to `OTEL_EXPORTER_OTLP_ENDPOINT=otel-gateway:4318` (direct OTLP)
+- Full span tree visible: `frontend` → `customer` → `driver` → `route` → `redis`
+- Every span carries `k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name`
+- "Logs for this span" in Tempo jumps directly to the correlated Loki logs
+
+---
+
+## Demo scripts
+
+Two scripts reproduce the before/after state on a local k3d cluster:
+
+- `demo-1-before.sh` — provisions the full stack in the pre-migration state
+- `demo-2-migrate-otel.sh` — runs the 8-step live migration
+
+See `OTEL_MIGRATION.md` run instructions or the script headers for prerequisites and usage.

--- a/OTEL_MIGRATION.md
+++ b/OTEL_MIGRATION.md
@@ -1,0 +1,234 @@
+# OpenTelemetry Migration — Demo Guide
+
+This document covers the full OTel migration scope added to `sre-stack`:
+a two-script demo that shows the observability stack **before** and **after** migrating
+to OpenTelemetry Collector, with Robot Shop + HotROD running on a local k3d cluster.
+
+---
+
+## Scope
+
+| Signal | Before | After |
+|--------|--------|-------|
+| **Logs** | Promtail → Loki 2.x (no trace correlation) | filelog (OTel agent) → OTel gateway → Loki 3.x (OTLP, structured metadata, trace\_id on every log) |
+| **Metrics** | Prometheus scraping only (no host/kubelet metrics) | hostmetrics + kubeletstats (OTel agent) + k8s\_cluster (gateway) → Prometheus remote\_write |
+| **Traces** | Istio ingress hops only (1–2 spans, no app-level detail) | App OTLP → OTel agent → gateway → Tempo (full span tree: frontend / DB / Redis calls) |
+| **Prometheus scraping** | ServiceMonitor-based | OTel gateway prometheusreceiver with kubernetes\_sd\_configs |
+| **K8s enrichment** | None | k8sattributes processor stamps `k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name` + all pod labels on every signal |
+
+---
+
+## Architecture
+
+### Before
+
+```
+Robot Shop pods ──► Promtail ──────────────────► Loki 2.x
+HotROD          ──► Jaeger endpoint (Istio)  ──► Tempo  (1-2 spans)
+All pods        ──► Prometheus scraping       ──► Prometheus
+                    (no host/kubelet metrics)
+```
+
+### After
+
+```
+                    ┌─────────────────────────────────────────────┐
+                    │  OTel Agent DaemonSet (one pod per node)    │
+Robot Shop pods ───►│  filelog | hostmetrics | kubeletstats        │
+HotROD          ───►│  k8sattributes processor                    │
+                    └──────────────┬──────────────────────────────┘
+                                   │ OTLP gRPC
+                                   ▼
+                    ┌─────────────────────────────────────────────┐
+                    │  OTel Gateway Deployment (o11y nodes)       │
+                    │  k8sobjects | k8s_cluster | prometheus rcvr │
+                    │  k8sattributes + resource processors        │
+                    └───┬──────────────┬────────────┬────────────┘
+                        │              │            │
+                        ▼              ▼            ▼
+                     Tempo          Prometheus   Loki 3.x
+                  (full traces)  (remote_write) (OTLP ingest)
+```
+
+---
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `demo-1-before.sh` | Builds the "before" state: k3d cluster + Istio + Prometheus + Loki 2.x + Tempo + Robot Shop + HotROD |
+| `demo-2-migrate-otel.sh` | Runs the full 8-step OTel migration live |
+| `app/robot-shop/robot-shop-local-values.yaml` | Helm overrides for the 4-node k3d cluster (single app node, no persistent node) |
+| `monitoring/chart-values/otel-agent-values.yaml` | OTel Agent DaemonSet — filelog, hostmetrics, kubeletstats |
+| `monitoring/chart-values/otel-gateway-values.yaml` | OTel Gateway Deployment — OTLP fan-out to Tempo + Prometheus + Loki |
+| `monitoring/chart-values/otel-gateway-prom-scrape-values.yaml` | Gateway with added prometheusreceiver (kubernetes\_sd\_configs) |
+| `monitoring/chart-values/loki-v3-values.yaml` | Loki 3.x (grafana/loki 7.0.0) — OTLP ingest, tsdb schema, allow\_structured\_metadata |
+
+---
+
+## Prerequisites
+
+- Docker Desktop (≥ 8 GB RAM allocated)
+- k3d ≥ 5.6
+- kubectl
+- helm ≥ 3.12
+- istioctl (for `make setup-istio`)
+- Ports 8080 and 18080 free on localhost
+
+---
+
+## Running the Demo
+
+### Step 1 — Build the "before" state
+
+```bash
+./demo-1-before.sh
+```
+
+This script:
+1. Deletes any existing `sre-stack-local` k3d cluster and creates a fresh 4-node one
+2. Labels nodes: `agent-0/1` → `workload=o11y` (tainted), `agent-2` → `workload=app`
+3. Installs: kube-prometheus-stack, Loki 2.x + Promtail, Tempo, Istio
+4. Deploys Robot Shop (with Istio sidecar injection) and HotROD
+5. Starts port-forwards: `localhost:8080` (Grafana + Robot Shop via Istio) and `localhost:18080` (HotROD)
+6. Sends 30 warmup requests to populate Istio metrics
+
+**Access:**
+- Grafana: `http://localhost:8080/grafana` (admin / prom-operator)
+- Robot Shop: `http://localhost:8080`
+- HotROD: `http://localhost:18080`
+
+**What to show (before — limitations):**
+
+| Check | Result |
+|-------|--------|
+| Application Dashboard → Service Map | ✅ Istio request rates visible |
+| Explore → Prometheus → `system_cpu_time_seconds_total` | ❌ No data — no host metrics |
+| Explore → Prometheus → `k8s_deployment_desired` | ❌ No data — no cluster-state metrics |
+| Explore → Tempo → Search | ❌ 1–2 Istio ingress spans only; no Redis/DB call visibility |
+| Explore → Loki → `{namespace="robot-shop"}` | ❌ Logs exist but no `trace_id` field |
+
+---
+
+### Step 2 — Run the OTel migration
+
+```bash
+./demo-2-migrate-otel.sh
+```
+
+Eight steps, each idempotent:
+
+| Step | What happens |
+|------|-------------|
+| 1 | Helm repo setup (open-telemetry, grafana, prometheus-community) |
+| 2 | Enable Prometheus `remote_write` receiver |
+| 3 | Uninstall loki-stack (Loki 2.x + Promtail) → install grafana/loki 7.0.0 (Loki 3.x, OTLP) |
+| 4 | Deploy OTel Gateway — receives OTLP from agents, fans out to Tempo / Prometheus / Loki |
+| 5 | Deploy OTel Agent DaemonSet — filelog + hostmetrics + kubeletstats on every node |
+| 6 | Rewire HotROD: remove `JAEGER_ENDPOINT`, set `OTEL_EXPORTER_OTLP_ENDPOINT=gateway:4318` |
+| 7 | Generate traffic: 40 Robot Shop requests + 20 HotROD dispatches |
+| 8 | Upgrade gateway to add prometheusreceiver (kubernetes\_sd\_configs scraping) |
+
+---
+
+## What to Validate After Migration
+
+### Logs (Loki 3.x)
+
+```
+Explore → Loki → {k8s_namespace_name="robot-shop"}
+```
+- Every log line has `k8s.pod.name`, `k8s.namespace.name`, `trace_id` as structured metadata
+- `trace_id` is clickable → jumps to the exact trace in Tempo
+
+### Traces (Tempo)
+
+```
+Explore → Tempo → Search → Service: hotrod
+```
+- Each dispatch shows 5+ spans: `frontend` → `customer` → `driver` → `route` → `redis`
+- Click any span → `k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name` visible
+- Click "Logs for this span" → correlated Loki logs for that pod/time window
+
+### Metrics (Prometheus)
+
+```
+Explore → Prometheus → system_cpu_time_seconds_total   # host metrics (OTel agent)
+Explore → Prometheus → k8s_deployment_desired          # cluster state (OTel gateway)
+Explore → Prometheus → container_cpu_usage_seconds_total # kubeletstats
+Explore → Prometheus → up{job="grafana"}               # OTel Prometheus scraping
+```
+
+### Application Dashboard
+
+- Service Map still populated (Istio `istio_requests_total` metrics continue)
+- Service Error Log panels now query Loki by pod name — no "No data"
+
+---
+
+## Key Design Decisions
+
+### Two-tier collector architecture
+
+The **agent** runs as a DaemonSet with `tolerations: [{operator: Exists}]` so it collects
+from every node including tainted o11y nodes. It only ships `filelog`, `hostmetrics`,
+and `kubeletstats` — node-local signals. Everything is forwarded via OTLP gRPC to the
+**gateway** Deployment which runs on the o11y nodes and handles enrichment and fan-out.
+
+This avoids giving every agent pod the RBAC rights needed to talk to Loki/Prometheus/Tempo,
+keeps exporter retry logic in one place, and lets you scale the gateway independently.
+
+### k8sattributes processor
+
+Both agent and gateway run `k8sattributes` with `extractAllPodLabels: true`. This stamps
+`k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name`, and every pod label on every span,
+metric, and log record. This is the single key that enables cross-signal correlation in Grafana
+without any application-side instrumentation changes.
+
+### Loki 3.x + OTLP ingest
+
+`loki-stack` (Loki 2.9) has no OTLP endpoint. `grafana/loki 7.0.0` (Loki 3.6.7) adds
+`/otlp/v1/logs` and `allow_structured_metadata: true`, which stores OTel attributes
+(including `trace_id`) alongside log lines as indexed structured metadata rather than
+requiring label cardinality to blow up.
+
+### `resource/loki-labels` processor
+
+Loki OTLP ingest won't index resource attributes as stream labels unless you tell it which
+ones to use. The `resource/loki-labels` processor inserts a `loki.resource.labels` hint:
+
+```yaml
+resource/loki-labels:
+  attributes:
+    - action: insert
+      key: loki.resource.labels
+      value: service.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,app
+```
+
+This keeps stream label cardinality low while making the labels the dashboard queries need
+available for filtering.
+
+### Local cluster overrides (`robot-shop-local-values.yaml`)
+
+The upstream Robot Shop chart targets a multi-node EKS cluster with separate persistent
+and app node groups. For the 4-node k3d demo cluster:
+
+- All `workload=persistent` nodeSelectors are redirected to `workload=app`
+- All replica counts reduced to 1 (avoids required podAntiAffinity on a single app node)
+- `affinity: null` (not `{}`) — Helm merges maps, so an empty map leaves base affinity
+  unchanged; `null` explicitly deletes the key
+
+---
+
+## Cluster Node Layout
+
+```
+k3d-sre-stack-local-server-0    control-plane
+k3d-sre-stack-local-agent-0     workload=o11y  (taint: o11y=true:NoSchedule)
+k3d-sre-stack-local-agent-1     workload=o11y  (taint: o11y=true:NoSchedule)
+k3d-sre-stack-local-agent-2     workload=app
+```
+
+OTel agents run on all 4 nodes (toleration: `Exists`).
+OTel gateway, Loki, Prometheus, Tempo, Grafana run on agent-0/1 (o11y nodes).
+Robot Shop and HotROD run on agent-2 (app node).

--- a/OTel/00-prereqs/install-macos.sh
+++ b/OTel/00-prereqs/install-macos.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Install the tools you need on macOS (MacBook Air). Idempotent — re-runs are safe.
+set -euo pipefail
+
+echo "==> Checking Homebrew"
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found. Install from https://brew.sh first, then re-run." >&2
+  exit 1
+fi
+
+echo "==> Installing Docker Desktop (if missing)"
+# Docker Desktop is required for kind. If you already have OrbStack or colima,
+# you can skip this — but the rest of the script assumes 'docker' resolves.
+if ! command -v docker >/dev/null 2>&1; then
+  brew install --cask docker
+  echo "Docker installed. Open Docker Desktop once so its daemon starts, then re-run this script."
+  exit 0
+fi
+
+echo "==> Installing CLI tools"
+brew install kubectl helm kind k9s jq yq
+
+echo "==> Versions"
+docker --version
+kubectl version --client --output=yaml | head -n 5
+helm version --short
+kind version
+k9s version --short || true
+
+echo
+echo "Prerequisites OK. Next: ./01-cluster/up.sh"

--- a/OTel/01-cluster/kind-cluster.yaml
+++ b/OTel/01-cluster/kind-cluster.yaml
@@ -1,0 +1,27 @@
+# 3-node kind cluster, sized for a MacBook Air.
+# - 1 control plane + 2 workers so DaemonSet behavior is realistic
+# - extraMounts expose the host filesystem for /var/log/pods readability
+# - port mappings let us hit Grafana / OTLP on localhost without port-forwarding
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: otel-lab
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 30080   # Grafana NodePort
+        hostPort: 3000
+        protocol: TCP
+      - containerPort: 30317   # OTLP gRPC (gateway NodePort)
+        hostPort: 4317
+        protocol: TCP
+      - containerPort: 30318   # OTLP HTTP (gateway NodePort)
+        hostPort: 4318
+        protocol: TCP
+  - role: worker
+  - role: worker

--- a/OTel/01-cluster/up.sh
+++ b/OTel/01-cluster/up.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CLUSTER_NAME="otel-lab"
+
+if kind get clusters | grep -q "^${CLUSTER_NAME}$"; then
+  echo "Cluster '${CLUSTER_NAME}' already exists — skipping create."
+else
+  echo "==> Creating kind cluster '${CLUSTER_NAME}'"
+  kind create cluster --config kind-cluster.yaml --wait 120s
+fi
+
+kubectl cluster-info --context "kind-${CLUSTER_NAME}"
+kubectl get nodes -o wide
+
+echo
+echo "Next: ./02-lgtm-stack/install.sh"

--- a/OTel/02-lgtm-stack/install.sh
+++ b/OTel/02-lgtm-stack/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+NS="observability"
+
+echo "==> Adding helm repos"
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+helm repo add grafana https://grafana.github.io/helm-charts >/dev/null
+helm repo update >/dev/null
+
+echo "==> Ensuring namespace ${NS}"
+kubectl get ns "${NS}" >/dev/null 2>&1 || kubectl create ns "${NS}"
+
+echo "==> Installing kube-prometheus-stack"
+helm upgrade --install kps prometheus-community/kube-prometheus-stack \
+  --namespace "${NS}" \
+  --values prometheus-values.yaml \
+  --wait --timeout 10m
+
+echo "==> Installing Loki (single-binary)"
+helm upgrade --install loki grafana/loki \
+  --namespace "${NS}" \
+  --values loki-values.yaml \
+  --wait --timeout 10m
+
+echo "==> Installing Tempo"
+helm upgrade --install tempo grafana/tempo \
+  --namespace "${NS}" \
+  --values tempo-values.yaml \
+  --wait --timeout 10m
+
+echo
+echo "==> Done. Grafana → http://localhost:3000  (admin / admin)"
+echo "Next: ./03-otel-collector/install.sh"

--- a/OTel/02-lgtm-stack/loki-values.yaml
+++ b/OTel/02-lgtm-stack/loki-values.yaml
@@ -1,0 +1,56 @@
+# Loki, single-binary mode, OTLP ingestion enabled.
+# We deliberately install with Promtail enabled at first (baseline), and
+# disable it in step 04-logs-migration once the collector is shipping logs.
+
+# CRITICAL: chart 7.x defaults to SimpleScalable mode. Without this flag,
+# setting read/write/backend replicas to 0 leaves you with zero Loki pods.
+deploymentMode: SingleBinary
+
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: filesystem
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+  # OTLP push endpoint at /otlp/v1/logs is enabled by default in Loki 3.x;
+  # leave it on so the OTel gateway can ship via otlphttp.
+  limits_config:
+    allow_structured_metadata: true
+    volume_enabled: true
+
+singleBinary:
+  replicas: 1
+  # Loki writes WAL + chunks to /var/loki. With persistence disabled the
+  # container's root filesystem is read-only, so it must have *some* writable
+  # volume — give it a 2Gi PVC backed by kind's local-path provisioner.
+  persistence:
+    enabled: true
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+# Disable everything we don't need in single-binary mode
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+
+# Promtail is shipped via the loki-stack chart as a separate release;
+# we control it from there.

--- a/OTel/02-lgtm-stack/prometheus-values.yaml
+++ b/OTel/02-lgtm-stack/prometheus-values.yaml
@@ -1,0 +1,87 @@
+# kube-prometheus-stack values, trimmed for a local lab.
+# Key tweaks:
+#  - enable the Prometheus remote_write receiver so the OTel collector can push
+#  - Grafana exposed via NodePort 30080 (mapped to host:3000 by kind)
+#  - Pre-load Prometheus, Loki, Tempo datasources with cross-signal correlation
+fullnameOverride: kps
+
+prometheus:
+  prometheusSpec:
+    enableRemoteWriteReceiver: true
+    # Keep retention small on a laptop
+    retention: 24h
+    resources:
+      requests:
+        cpu: 100m
+        memory: 400Mi
+    # Pick up ServiceMonitors from any namespace, no label selector
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+
+alertmanager:
+  enabled: false  # not needed for the lab
+
+# Disable cAdvisor scraping noise on kind (kubelet cAdvisor metrics path differs)
+kubeApiServer:
+  enabled: true
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeProxy:
+  enabled: false
+
+grafana:
+  enabled: true
+  service:
+    type: NodePort
+    nodePort: 30080
+  adminPassword: admin
+  defaultDashboardsTimezone: browser
+  # Pre-wire the three datasources so trace ↔ logs ↔ metrics linking works
+  # out of the box. The `derivedFields` and `tracesToLogsV2` blocks are what
+  # actually wire correlation together.
+  additionalDataSources:
+    - name: Loki
+      type: loki
+      url: http://loki.observability.svc:3100
+      access: proxy
+      jsonData:
+        derivedFields:
+          - datasourceUid: tempo
+            matcherRegex: "trace_id=(\\w+)"
+            name: TraceID
+            url: "$${__value.raw}"
+    - name: Tempo
+      type: tempo
+      uid: tempo
+      # Tempo's HTTP query API is on 3200 (not 3100 — that's Loki).
+      # OTLP gRPC for ingestion is on 4317 and is configured in the
+      # collector's otlp/tempo exporter separately.
+      url: http://tempo.observability.svc:3200
+      access: proxy
+      jsonData:
+        tracesToLogsV2:
+          datasourceUid: loki
+          spanStartTimeShift: "-5m"
+          spanEndTimeShift: "5m"
+          tags:
+            - key: service.name
+              value: service_name
+            - key: k8s.pod.name
+              value: pod
+            - key: k8s.namespace.name
+              value: namespace
+          filterByTraceID: true
+        tracesToMetrics:
+          datasourceUid: prometheus
+          tags:
+            - key: service.name
+              value: service
+        serviceMap:
+          datasourceUid: prometheus
+        nodeGraph:
+          enabled: true

--- a/OTel/02-lgtm-stack/tempo-values.yaml
+++ b/OTel/02-lgtm-stack/tempo-values.yaml
@@ -1,0 +1,22 @@
+# Tempo single-binary, OTLP receivers on. Grafana will discover traces here.
+tempo:
+  metricsGenerator:
+    enabled: true
+    remoteWriteUrl: http://kps-prometheus.observability.svc:9090/api/v1/write
+  storage:
+    trace:
+      backend: local
+      local:
+        path: /var/tempo/traces
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+persistence:
+  enabled: false  # ephemeral; OK for a lab
+
+# Service exposes 4317 (OTLP gRPC), 4318 (OTLP HTTP), 3100 (Tempo HTTP API)
+service:
+  type: ClusterIP

--- a/OTel/03-otel-collector/agent-values.yaml
+++ b/OTel/03-otel-collector/agent-values.yaml
@@ -1,0 +1,65 @@
+# OTel Collector — AGENT tier (DaemonSet, one pod per node)
+#
+# Step 3 scope: OTLP-in, OTLP-out to the gateway, with k8sattributes enrichment.
+# Logs (filelog) and host/kubelet metrics receivers come in steps 04 and 05.
+mode: daemonset
+fullnameOverride: otel-agent
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+# Pre-baked presets handle RBAC + the fiddly volume mounts for us
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+    extractAllPodAnnotations: false
+
+resources:
+  limits:
+    cpu: 256m
+    memory: 512Mi
+
+# Mount host /var/log/pods later for filelog (step 04). Not needed yet.
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+    # k8sattributes is injected automatically by the preset above
+
+  exporters:
+    # Forward everything to the gateway. The Service name follows the
+    # opentelemetry-collector chart pattern: <release>-collector.
+    otlp/gateway:
+      endpoint: otel-gateway.observability.svc:4317
+      tls:
+        insecure: true
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      logs:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]

--- a/OTel/03-otel-collector/gateway-values.yaml
+++ b/OTel/03-otel-collector/gateway-values.yaml
@@ -1,0 +1,83 @@
+# OTel Collector — GATEWAY tier (Deployment, cluster-wide)
+#
+# Receives from agents over OTLP, applies cluster-level processing, exports
+# to backends. Step 3 wires traces → Tempo only; logs (step 04) and metrics
+# (step 05) get exporters wired up later.
+mode: deployment
+replicaCount: 1
+fullnameOverride: otel-gateway
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+
+# Expose OTLP via NodePort so you can `curl` from your laptop too
+service:
+  type: NodePort
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    nodePort: 30317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    nodePort: 30318
+    protocol: TCP
+
+resources:
+  limits:
+    cpu: 512m
+    memory: 1Gi
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+    # k8sattributes auto-injected by preset
+
+  exporters:
+    # Traces → Tempo
+    otlp/tempo:
+      endpoint: tempo.observability.svc:4317
+      tls:
+        insecure: true
+    # Logs (Loki OTLP) and Metrics (Prometheus remote_write) wired in steps 04 / 05
+    debug:
+      verbosity: basic
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/tempo]
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [debug]   # placeholder — replaced in step 05
+      logs:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [debug]   # placeholder — replaced in step 04

--- a/OTel/03-otel-collector/install.sh
+++ b/OTel/03-otel-collector/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+NS="observability"
+
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts >/dev/null
+helm repo update >/dev/null
+
+echo "==> Installing OTel Collector — gateway (Deployment)"
+helm upgrade --install otel-gateway open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  --values gateway-values.yaml \
+  --wait --timeout 5m
+
+echo "==> Installing OTel Collector — agent (DaemonSet)"
+helm upgrade --install otel-agent open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  --values agent-values.yaml \
+  --wait --timeout 5m
+
+echo
+echo "Verify with:"
+echo "  kubectl -n ${NS} get pods -l 'app.kubernetes.io/name=opentelemetry-collector'"
+echo
+echo "Smoke test (send one trace via OTLP HTTP to the gateway NodePort):"
+cat <<'EOF'
+  curl -s -X POST http://localhost:4318/v1/traces \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "resourceSpans": [{
+        "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "smoke-test"}}]},
+        "scopeSpans": [{
+          "spans": [{
+            "traceId": "00112233445566778899aabbccddeeff",
+            "spanId":  "1122334455667788",
+            "name":    "hello",
+            "kind":    1,
+            "startTimeUnixNano": "1700000000000000000",
+            "endTimeUnixNano":   "1700000000100000000"
+          }]
+        }]
+      }]
+    }'
+EOF
+echo
+echo "Then open Grafana → Tempo and search service.name=smoke-test."
+echo "Next: ./04-logs-migration/apply.sh"

--- a/OTel/04-logs-migration/agent-values.yaml
+++ b/OTel/04-logs-migration/agent-values.yaml
@@ -1,0 +1,64 @@
+# Agent values — step 04 adds filelogreceiver on each node.
+# Diff vs step 03: presets.logsCollection enabled.
+mode: daemonset
+fullnameOverride: otel-agent
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+  # NEW: tail /var/log/pods/**/*.log, parse CRI format, attach pod metadata.
+  # The preset also mounts the host paths and adds the right RBAC.
+  logsCollection:
+    enabled: true
+    includeCollectorLogs: false   # avoid feedback loops
+    storeCheckpoints: true        # checkpoints survive restarts
+
+resources:
+  limits:
+    cpu: 256m
+    memory: 512Mi
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    # filelog receiver is injected by the preset under the name `filelog`.
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+
+  exporters:
+    otlp/gateway:
+      endpoint: otel-gateway.observability.svc:4317
+      tls:
+        insecure: true
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      logs:
+        # filelog from the preset + any OTLP-emitted application logs
+        receivers: [otlp, filelog]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]

--- a/OTel/04-logs-migration/apply.sh
+++ b/OTel/04-logs-migration/apply.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+NS="observability"
+
+echo "==> Upgrading gateway with k8s_events receiver + Loki exporter"
+helm upgrade otel-gateway open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  --values gateway-values.yaml \
+  --wait --timeout 5m
+
+echo "==> Upgrading agent with filelog receiver"
+helm upgrade otel-agent open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  --values agent-values.yaml \
+  --wait --timeout 5m
+
+cat <<'EOF'
+
+Verify:
+  # 1) Agent pods should now mount /var/log/pods
+  kubectl -n observability exec ds/otel-agent-agent -- ls /var/log/pods | head
+
+  # 2) Open Grafana → Explore → Loki, query:
+  #      {service_name=~".+"}     (any service)
+  #      {k8s_namespace_name="observability"}
+
+  # 3) Kubernetes events should appear with:
+  #      {k8s_resource_name=~".+"}
+
+If you had Promtail installed previously, retire it now:
+  helm uninstall promtail -n observability   # only if it exists
+
+Next: ./05-metrics-migration/apply.sh
+EOF

--- a/OTel/04-logs-migration/gateway-values.yaml
+++ b/OTel/04-logs-migration/gateway-values.yaml
@@ -1,0 +1,91 @@
+# Gateway values — step 04 adds:
+#  - k8s_events receiver (cluster-wide, so only on the gateway)
+#  - otlphttp/loki exporter wired into the logs pipeline (replaces `debug`)
+mode: deployment
+replicaCount: 1
+fullnameOverride: otel-gateway
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+  # NEW: cluster-wide Kubernetes events ingestion (events → log records).
+  kubernetesEvents:
+    enabled: true
+
+service:
+  type: NodePort
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    nodePort: 30317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    nodePort: 30318
+    protocol: TCP
+
+resources:
+  limits:
+    cpu: 512m
+    memory: 1Gi
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    # k8s_events injected by the preset under the name `k8s_events`.
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+    # Normalize resource attribute names for Loki/Grafana correlation.
+    # service.name → loki label `service_name`, k8s.pod.name → `pod`, etc.
+    resource/loki-labels:
+      attributes:
+        - action: insert
+          key: loki.resource.labels
+          value: service.name,k8s.namespace.name,k8s.pod.name,k8s.container.name
+
+  exporters:
+    otlp/tempo:
+      endpoint: tempo.observability.svc:4317
+      tls:
+        insecure: true
+    # NEW: ship logs to Loki via OTLP HTTP (replaces the deprecated `loki` exporter).
+    otlphttp/loki:
+      endpoint: http://loki.observability.svc:3100/otlp
+      tls:
+        insecure: true
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/tempo]
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/tempo]   # placeholder, replaced in step 05
+      logs:
+        receivers: [otlp, k8sobjects]
+        processors: [memory_limiter, k8sattributes, resource/loki-labels, batch]
+        exporters: [otlphttp/loki]

--- a/OTel/05-metrics-migration/agent-values.yaml
+++ b/OTel/05-metrics-migration/agent-values.yaml
@@ -1,0 +1,79 @@
+# Agent values — step 05 layers host + kubelet metrics on top of step 04.
+mode: daemonset
+fullnameOverride: otel-agent
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+  logsCollection:
+    enabled: true
+    includeCollectorLogs: false
+    storeCheckpoints: true
+  # NEW: node-level metrics. The chart mounts /, /proc, /sys appropriately
+  # and adds the matching receiver config.
+  hostMetrics:
+    enabled: true
+  # NEW: kubelet /metrics/stats, pod/container/volume metrics
+  kubeletMetrics:
+    enabled: true
+
+resources:
+  limits:
+    cpu: 256m
+    memory: 512Mi
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    # hostmetrics injected by preset
+    # kubeletstats is injected by the preset but we override insecure_skip_verify
+    # because kind's kubelet cert has no IP SANs and fails default TLS validation.
+    kubeletstats:
+      collection_interval: 20s
+      auth_type: serviceAccount
+      endpoint: ${env:OTEL_K8S_NODE_IP}:10250
+      insecure_skip_verify: true
+      metric_groups:
+        - node
+        - pod
+        - container
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+
+  exporters:
+    otlp/gateway:
+      endpoint: otel-gateway.observability.svc:4317
+      tls:
+        insecure: true
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      metrics:
+        # otlp = app metrics; hostmetrics = node; kubeletstats = pod/container
+        receivers: [otlp, hostmetrics, kubeletstats]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      logs:
+        receivers: [otlp, filelog]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]

--- a/OTel/05-metrics-migration/apply.sh
+++ b/OTel/05-metrics-migration/apply.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+NS="observability"
+
+echo "==> Upgrading gateway with k8s_cluster + prometheusremotewrite"
+helm upgrade otel-gateway open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  --values gateway-values.yaml \
+  --wait --timeout 5m
+
+echo "==> Upgrading agent with hostmetrics + kubeletstats"
+helm upgrade otel-agent open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  --values agent-values.yaml \
+  --wait --timeout 5m
+
+cat <<'EOF'
+
+Verify in Grafana → Explore → Prometheus:
+  # node metrics from hostmetricsreceiver
+  system_cpu_load_average_1m
+  system_memory_usage_bytes{state="used"}
+
+  # kubelet pod/container metrics
+  k8s_pod_cpu_utilization
+  k8s_container_memory_usage
+
+  # cluster receiver
+  k8s_node_condition_ready
+  k8s_pod_phase
+
+Next: ./06-validation/deploy-demo.sh
+EOF

--- a/OTel/05-metrics-migration/gateway-values.yaml
+++ b/OTel/05-metrics-migration/gateway-values.yaml
@@ -1,0 +1,102 @@
+# Gateway values — step 05 adds:
+#  - k8s_cluster receiver (cluster-wide kube-state-style metrics)
+#  - prometheusremotewrite exporter pointed at Prometheus
+mode: deployment
+replicaCount: 1
+fullnameOverride: otel-gateway
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+  kubernetesEvents:
+    enabled: true
+  # NEW: cluster-level metrics (node/pod counts, conditions, container states)
+  clusterMetrics:
+    enabled: true
+
+service:
+  type: NodePort
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    nodePort: 30317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    nodePort: 30318
+    protocol: TCP
+
+resources:
+  limits:
+    cpu: 512m
+    memory: 1Gi
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    # k8s_events + k8s_cluster injected by presets
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+    resource/loki-labels:
+      attributes:
+        - action: insert
+          key: loki.resource.labels
+          value: service.name,k8s.namespace.name,k8s.pod.name,k8s.container.name
+
+  exporters:
+    otlp/tempo:
+      endpoint: tempo.observability.svc:4317
+      tls:
+        insecure: true
+    otlphttp/loki:
+      endpoint: http://loki.observability.svc:3100/otlp
+      tls:
+        insecure: true
+    # NEW: metrics → Prometheus via remote_write
+    prometheusremotewrite/prom:
+      endpoint: http://kps-prometheus.observability.svc:9090/api/v1/write
+      tls:
+        insecure: true
+      # Promote useful resource attributes to Prometheus labels
+      resource_to_telemetry_conversion:
+        enabled: true
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/tempo]
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      metrics/cluster:
+        receivers: [k8s_cluster]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      logs:
+        receivers: [otlp, k8sobjects]
+        processors: [memory_limiter, k8sattributes, resource/loki-labels, batch]
+        exporters: [otlphttp/loki]

--- a/OTel/06-validation/demo.yaml
+++ b/OTel/06-validation/demo.yaml
@@ -1,0 +1,86 @@
+# Three short-lived workloads, all using service.name="demo-app", emitting one
+# signal each through the agent's local OTLP endpoint (the DaemonSet exposes
+# 4317 on every node's pod IP — we resolve via the agent's headless Service).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+---
+# Traces — telemetrygen sends 100 spans
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: demo-traces
+  namespace: demo
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: gen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
+          args:
+            - traces
+            - --otlp-endpoint=otel-gateway.observability.svc:4317
+            - --otlp-insecure
+            - --duration=30s
+            - --rate=5
+            - --otlp-attributes=service.name="demo-app"
+            - --otlp-attributes=service.namespace="demo"
+---
+# Metrics
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: demo-metrics
+  namespace: demo
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: gen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
+          args:
+            - metrics
+            - --otlp-endpoint=otel-gateway.observability.svc:4317
+            - --otlp-insecure
+            - --duration=30s
+            - --rate=5
+            - --otlp-attributes=service.name="demo-app"
+---
+# Logs — emit via stdout so filelogreceiver picks them up too
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-logger
+  namespace: demo
+  labels:
+    app: demo-logger
+    service.name: demo-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-logger
+  template:
+    metadata:
+      labels:
+        app: demo-logger
+        service.name: demo-app   # surfaced by k8sattributes preset
+    spec:
+      containers:
+        - name: logger
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              i=0
+              while true; do
+                i=$((i+1))
+                echo "ts=$(date -Iseconds) level=info msg='demo log line' trace_id=00112233445566778899aabbccddee$(printf '%02d' $((i % 100)))"
+                sleep 2
+              done

--- a/OTel/06-validation/deploy-demo.sh
+++ b/OTel/06-validation/deploy-demo.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+kubectl apply -f demo.yaml
+kubectl -n demo wait --for=condition=available --timeout=60s deploy/demo-logger || true
+
+cat <<'EOF'
+
+==> Demo deployed. Cross-signal checks to run in Grafana (http://localhost:3000):
+
+1) Traces in Tempo
+   Explore → Tempo → "Search" tab → service.name="demo-app"
+   You should see ~150 spans from the 30s, rate=5 job.
+
+2) Logs in Loki — confirm filelog is picking up demo-logger stdout
+   Explore → Loki → {k8s_namespace_name="demo"}
+   You should see "demo log line" entries with k8s_pod_name, service_name labels.
+
+3) Metrics in Prometheus — confirm hostmetrics + telemetrygen metrics flow
+   Explore → Prometheus →   system_cpu_load_average_1m
+                            gen_by_telemetrygen{service_name="demo-app"}
+
+4) Correlation: pick any span in Tempo → "Logs for this span" button → should
+   land in Loki filtered by the same service.name / pod.
+
+5) Kubernetes events as logs:
+   Explore → Loki → {k8s_resource_name=~".+"}
+EOF

--- a/OTel/07-prometheus-scrape-migration/apply.sh
+++ b/OTel/07-prometheus-scrape-migration/apply.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Step 07 — migrate Prometheus scraping into the collector.
+#
+# IMPORTANT: this step does NOT stop Prometheus from scraping. Both Prometheus
+# AND the collector will scrape simultaneously until you narrow the
+# ServiceMonitor selector on ONE side (or the other) to avoid duplicate
+# series. That's intentional — you verify the collector is producing the
+# right series before turning Prometheus scraping off.
+#
+# Recommended phasing:
+#   1. Apply this file (collector starts scraping every ServiceMonitor).
+#   2. In Grafana, compare a metric like `up{job="kps-kube-state-metrics"}`
+#      — you should see two series, one from each scraper.
+#   3. Drop one ServiceMonitor from Prometheus (set scrape selector or label
+#      it explicitly so Prometheus ignores it).
+#   4. Repeat per ServiceMonitor until Prometheus is just a store.
+set -euo pipefail
+cd "$(dirname "$0")"
+NS="observability"
+
+echo "==> Upgrading gateway with prometheusreceiver + target-allocator"
+helm upgrade otel-gateway open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  --values gateway-values.yaml \
+  --wait --timeout 5m
+
+echo
+echo "Verify:"
+echo "  # target-allocator should have discovered ServiceMonitors:"
+echo "  kubectl -n ${NS} port-forward svc/otel-gateway-targetallocator 8080:80"
+echo "  curl -s http://localhost:8080/scrape_configs | jq 'keys'"
+echo
+echo "  # in Grafana, look for duplicate \`up\` series (one from kps-prometheus"
+echo "  # scraping, one from the collector). Once you're happy, narrow the"
+echo "  # Prometheus serviceMonitorSelector to phase scraping out."

--- a/OTel/07-prometheus-scrape-migration/gateway-values.yaml
+++ b/OTel/07-prometheus-scrape-migration/gateway-values.yaml
@@ -1,0 +1,125 @@
+# Gateway values — step 07 ADDS the prometheusreceiver and a target-allocator
+# so the collector takes over scraping from Prometheus, ServiceMonitor by
+# ServiceMonitor. This is the incremental path the scope calls for: we keep
+# Prometheus running as a metrics *store* (remote_write target) but move
+# *scraping* into the collector tier.
+mode: deployment
+replicaCount: 1
+fullnameOverride: otel-gateway
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+  kubernetesEvents:
+    enabled: true
+  clusterMetrics:
+    enabled: true
+
+# NEW: target allocator — discovers ServiceMonitors/PodMonitors and assigns
+# scrape targets to gateway replicas. With one replica it's overkill, but it
+# makes the scrape config declarative and matches the production pattern.
+targetAllocator:
+  enabled: true
+  replicas: 1
+  allocationStrategy: consistent-hashing
+  prometheusCR:
+    enabled: true
+    # Pick up every ServiceMonitor/PodMonitor in the cluster, no label filter.
+    # Tighten this later by setting serviceMonitorSelector to phase the
+    # migration ServiceMonitor-by-ServiceMonitor (scope explicitly says
+    # "start with a couple of ServiceMonitors").
+    serviceMonitorSelector: {}
+    podMonitorSelector: {}
+
+service:
+  type: NodePort
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    nodePort: 30317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    nodePort: 30318
+    protocol: TCP
+
+resources:
+  limits:
+    cpu: 1
+    memory: 1Gi
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc: { endpoint: 0.0.0.0:4317 }
+        http: { endpoint: 0.0.0.0:4318 }
+    # NEW: prometheus receiver. The target-allocator fills in scrape configs
+    # at runtime from the CRs it discovers, so we declare an empty static
+    # config block and point the receiver at the allocator.
+    prometheus:
+      config:
+        scrape_configs: []
+      target_allocator:
+        endpoint: http://otel-gateway-targetallocator:80
+        interval: 30s
+        collector_id: ${env:POD_NAME}
+    # k8s_events + k8s_cluster injected by presets
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+    resource/loki-labels:
+      attributes:
+        - action: insert
+          key: loki.resource.labels
+          value: service.name,k8s.namespace.name,k8s.pod.name,k8s.container.name
+
+  exporters:
+    otlp/tempo:
+      endpoint: tempo.observability.svc:4317
+      tls: { insecure: true }
+    otlphttp/loki:
+      endpoint: http://loki.observability.svc:3100/otlp
+      tls: { insecure: true }
+    prometheusremotewrite/prom:
+      endpoint: http://kps-prometheus.observability.svc:9090/api/v1/write
+      tls: { insecure: true }
+      resource_to_telemetry_conversion:
+        enabled: true
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/tempo]
+      # OTLP-pushed app metrics (from agents) AND scraped metrics
+      # (via the prometheus receiver) share one pipeline so they get the same
+      # k8sattributes treatment and ship out the same exporter.
+      metrics:
+        receivers: [otlp, prometheus]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      metrics/cluster:
+        receivers: [k8s_cluster]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      logs:
+        receivers: [otlp, k8sobjects]
+        processors: [memory_limiter, k8sattributes, resource/loki-labels, batch]
+        exporters: [otlphttp/loki]

--- a/OTel/08-yace-decision/README.md
+++ b/OTel/08-yace-decision/README.md
@@ -1,0 +1,31 @@
+# YACE migration decision
+
+The scope says: **decide YACE migration path — keep YACE (simpler) OR use
+`awscloudwatchreceiver` in the collector (unified but heavier config).**
+
+Both options are implemented below. Pick one and apply it; you do not need both.
+
+## Option A — keep YACE
+
+Best when: you already run YACE in prod, the CloudWatch metric list is large,
+or you don't want CloudWatch metrics to participate in collector-side
+redaction/tail-sampling. YACE writes directly to Prometheus; the collector
+ignores it entirely.
+
+Apply: `./option-a-keep-yace/apply.sh`
+
+## Option B — `awscloudwatchreceiver` in the gateway
+
+Best when: you want one ingestion backbone, consistent `k8sattributes` on AWS
+metrics, or you only have a handful of CloudWatch namespaces. Heavier config
+because every namespace needs an explicit `metric_name_selector` block.
+
+Apply: `./option-b-cloudwatch-receiver/apply.sh`
+
+## Recommendation
+
+For this repo: **start with Option A**. It's a no-op against existing YACE
+deployments and decouples the AWS migration from the rest of the work in the
+parent issue. Move to Option B once the collector tiers are stable and you
+have a real driver (consistent redaction across signals, multi-account
+fan-out, etc.).

--- a/OTel/08-yace-decision/option-a-keep-yace/apply.sh
+++ b/OTel/08-yace-decision/option-a-keep-yace/apply.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+NS="observability"
+
+helm repo add nerdswords https://nerdswords.github.io/helm-charts >/dev/null
+helm repo update >/dev/null
+
+echo "==> Installing YACE (writes directly to Prometheus via ServiceMonitor)"
+helm upgrade --install yace nerdswords/yet-another-cloudwatch-exporter \
+  --namespace "${NS}" \
+  --values yace-values.yaml \
+  --wait --timeout 5m
+
+echo "Done. CloudWatch metrics will appear in Prometheus tagged with the"
+echo "YACE job labels. Collector configs need no changes for this path."

--- a/OTel/08-yace-decision/option-a-keep-yace/yace-values.yaml
+++ b/OTel/08-yace-decision/option-a-keep-yace/yace-values.yaml
@@ -1,0 +1,32 @@
+# YACE Helm values — keep YACE as-is, write directly to Prometheus.
+# Chart: nerdswords/yet-another-cloudwatch-exporter
+serviceMonitor:
+  enabled: true   # so kube-prometheus-stack picks it up automatically
+
+# Example: scrape EC2 + RDS metrics. Replace with your real namespaces.
+config: |-
+  apiVersion: v1alpha1
+  sts-region: us-east-1
+  discovery:
+    jobs:
+      - type: AWS/EC2
+        regions: [us-east-1]
+        metrics:
+          - name: CPUUtilization
+            statistics: [Average]
+            period: 300
+            length: 300
+      - type: AWS/RDS
+        regions: [us-east-1]
+        metrics:
+          - name: CPUUtilization
+            statistics: [Average]
+            period: 300
+            length: 300
+
+# AWS credentials — point at a Secret you create out of band:
+#   kubectl -n observability create secret generic yace-aws \
+#     --from-literal=AWS_ACCESS_KEY_ID=... \
+#     --from-literal=AWS_SECRET_ACCESS_KEY=...
+extraEnvSecrets:
+  - yace-aws

--- a/OTel/08-yace-decision/option-b-cloudwatch-receiver/apply.sh
+++ b/OTel/08-yace-decision/option-b-cloudwatch-receiver/apply.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+NS="observability"
+
+if ! kubectl -n "${NS}" get secret otel-aws >/dev/null 2>&1; then
+  echo "Create the otel-aws Secret first (see overlay file header)." >&2
+  exit 1
+fi
+
+echo "==> Upgrading gateway with awscloudwatchreceiver"
+helm upgrade otel-gateway open-telemetry/opentelemetry-collector \
+  --namespace "${NS}" \
+  -f ../../05-metrics-migration/gateway-values.yaml \
+  -f gateway-overlay-values.yaml \
+  --wait --timeout 5m
+
+echo "Done. AWS metrics now flow through the collector — apply k8sattributes,"
+echo "redaction, and routing uniformly with the rest of the signals."

--- a/OTel/08-yace-decision/option-b-cloudwatch-receiver/gateway-overlay-values.yaml
+++ b/OTel/08-yace-decision/option-b-cloudwatch-receiver/gateway-overlay-values.yaml
@@ -1,0 +1,40 @@
+# Overlay onto 05-metrics-migration/gateway-values.yaml (or 07).
+# Adds awscloudwatchreceiver to the gateway's metrics pipeline.
+#
+# Apply with:
+#   helm upgrade otel-gateway open-telemetry/opentelemetry-collector \
+#     -n observability \
+#     -f ../../05-metrics-migration/gateway-values.yaml \
+#     -f gateway-overlay-values.yaml
+#
+# AWS creds: collector reads them from env. Create a Secret and mount it:
+#   kubectl -n observability create secret generic otel-aws \
+#     --from-literal=AWS_ACCESS_KEY_ID=... \
+#     --from-literal=AWS_SECRET_ACCESS_KEY=... \
+#     --from-literal=AWS_REGION=us-east-1
+extraEnvsFrom:
+  - secretRef:
+      name: otel-aws
+
+config:
+  receivers:
+    awscloudwatch:
+      region: us-east-1
+      poll_interval: 5m
+      metrics:
+        named:
+          - namespace: AWS/EC2
+            metric_name: CPUUtilization
+            period: 300s
+            aws_aggregation: Average
+          - namespace: AWS/RDS
+            metric_name: CPUUtilization
+            period: 300s
+            aws_aggregation: Average
+
+  service:
+    pipelines:
+      metrics:
+        receivers: [otlp, awscloudwatch]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]

--- a/OTel/README.md
+++ b/OTel/README.md
@@ -1,0 +1,78 @@
+# OTel Collector Migration — Local Lab (macOS / kind)
+
+End-to-end implementation of the "unified ingestion via OTel Collector" plan from
+the design issue. Walks you from an empty MacBook Air to a working LGTM stack
+where logs, metrics, traces, and k8s events all flow through a two-tier
+collector (agent DaemonSet + gateway Deployment).
+
+## Topology — before vs after
+
+**Before (fragmented):**
+
+```
+Apps ──► Prometheus (scrape)
+Apps ──► Promtail ──► Loki
+Apps ──► OTel SDK ──► Tempo
+CloudWatch ──► YACE ──► Prometheus
+k8s events ──► (not collected)
+host metrics ──► (not collected)
+```
+
+**After (unified):**
+
+```
+                                 ┌──────────────────────────┐
+Apps (OTLP) ───────────┐         │   OTel Gateway           │
+                       ├────────►│   (Deployment)           ├──► Tempo  (traces)
+Pod logs (filelog) ────┤         │   - k8sattributes        ├──► Loki   (logs)
+Host metrics ──────────┤         │   - tail_sampling        ├──► Prom   (metrics, via RW)
+Kubelet stats ─────────┘         │   - batch / memory_limit │
+       (Agent DaemonSet)         └──────────────────────────┘
+                                          ▲
+k8s events / cluster metrics ─────────────┘
+       (gateway-only receivers)
+```
+
+## Step-by-step
+
+Each folder is one rollback unit. Run them in order; you can stop at any step
+and still have a working stack.
+
+| Step | Folder | What it does |
+|------|--------|--------------|
+| 0    | `00-prereqs/`         | Install Docker, kubectl, helm, kind on macOS |
+| 1    | `01-cluster/`         | Create a 3-node kind cluster |
+| 2    | `02-lgtm-stack/`      | Install Prometheus, Loki, Tempo, Grafana via Helm |
+| 3    | `03-otel-collector/`  | Deploy collector in two tiers (agent + gateway) |
+| 4    | `04-logs-migration/`  | Switch logs to filelogreceiver + k8seventsreceiver, retire Promtail |
+| 5    | `05-metrics-migration/` | Add hostmetrics + kubeletstats + k8scluster receivers, ship via remote_write |
+| 6    | `06-validation/`      | Deploy a sample app, verify trace ↔ logs ↔ metrics correlation |
+| 7    | `07-prometheus-scrape-migration/` | (Optional) move scraping from Prometheus into the collector via `prometheusreceiver` + target-allocator |
+| 8    | `08-yace-decision/`   | Pick a path for AWS CloudWatch metrics — keep YACE OR use `awscloudwatchreceiver` |
+
+## Quick start
+
+```bash
+# from this folder
+./00-prereqs/install-macos.sh
+./01-cluster/up.sh
+./02-lgtm-stack/install.sh
+./03-otel-collector/install.sh
+./04-logs-migration/apply.sh
+./05-metrics-migration/apply.sh
+./06-validation/deploy-demo.sh
+```
+
+Each `apply.sh` is idempotent — re-running it just upgrades the Helm release.
+
+## Tearing down
+
+```bash
+kind delete cluster --name otel-lab
+```
+
+## References
+
+- Collector deployment patterns: https://opentelemetry.io/docs/collector/deployment/
+- opentelemetry-collector Helm chart: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
+- Grafana LGTM correlation: https://grafana.com/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#trace-to-logs

--- a/OTel/docs/architecture.md
+++ b/OTel/docs/architecture.md
@@ -1,0 +1,88 @@
+# Architecture — unified ingestion via OTel Collector
+
+## Before — fragmented topology
+
+```mermaid
+flowchart LR
+  apps[Apps]
+  promtail[Promtail DaemonSet]
+  yace[YACE]
+  cw[(CloudWatch)]
+
+  apps -->|scrape| prom[(Prometheus)]
+  apps -->|stdout| promtail
+  promtail --> loki[(Loki)]
+  apps -->|OTLP| tempo[(Tempo)]
+  cw --> yace --> prom
+  events[K8s events] -. not collected .-> x((✗))
+  host[Host metrics] -. not collected .-> x
+```
+
+Each signal owns its own collection mechanism. Pod metadata, redaction, and
+tail-sampling have to be configured per-tool (or are missing entirely).
+
+## After — collector as the ingestion backbone
+
+```mermaid
+flowchart LR
+  subgraph node[Each node]
+    agent[OTel Agent\nDaemonSet]
+  end
+  subgraph cluster[Cluster-wide]
+    gateway[OTel Gateway\nDeployment]
+  end
+
+  apps[Apps] -->|OTLP| agent
+  podlogs[/var/log/pods/**] -->|filelog| agent
+  hostm[Host /proc, /sys] -->|hostmetrics| agent
+  kubelet[Kubelet /stats] -->|kubeletstats| agent
+
+  agent -->|OTLP gRPC| gateway
+
+  k8sapi[K8s API] -->|k8s_events| gateway
+  k8sapi -->|k8s_cluster| gateway
+
+  gateway -->|OTLP| tempo[(Tempo)]
+  gateway -->|OTLP HTTP| loki[(Loki)]
+  gateway -->|remote_write| prom[(Prometheus)]
+```
+
+### What each tier owns
+
+| Tier | Receivers | Why it lives here |
+|------|-----------|-------------------|
+| **Agent** (DaemonSet) | `otlp`, `filelog`, `hostmetrics`, `kubeletstats` | Anything that needs node-local filesystem or kubelet access |
+| **Gateway** (Deployment) | `otlp`, `k8s_events`, `k8s_cluster` | Anything cluster-wide; central place for tail sampling, redaction, batching, fan-out |
+
+Every pipeline runs the `k8sattributes` processor, so traces, logs, and
+metrics all carry the same `service.name`, `k8s.pod.name`,
+`k8s.namespace.name`, `k8s.node.name` — which is what makes Grafana
+trace ↔ log ↔ metric jumps actually land on the right row.
+
+## Rollback per step
+
+Each step folder is one Helm upgrade you can roll back independently:
+
+```bash
+# Roll a single step back to the previous values
+helm rollback otel-gateway -n observability
+helm rollback otel-agent   -n observability
+
+# Or revert to a specific step's values explicitly
+helm upgrade otel-gateway open-telemetry/opentelemetry-collector \
+  -n observability -f 03-otel-collector/gateway-values.yaml
+```
+
+## YACE decision (out-of-scope for this lab)
+
+Two paths if you later need AWS CloudWatch metrics:
+
+1. **Keep YACE.** Simpler config; YACE writes to Prometheus, the collector
+   reads from there or ignores it entirely. No collector changes.
+2. **Use `awscloudwatchreceiver`.** Unified config under the same collector
+   pipeline (consistent k8sattributes, redaction, etc.) but configuration
+   is significantly heavier per-metric. Recommended once you have >1 AWS
+   account to deal with or when CloudWatch metrics need to participate in
+   the same redaction/tail-sampling rules as the rest.
+
+This lab does not deploy either, since AWS isn't in scope.

--- a/OTel/docs/demo-script.md
+++ b/OTel/docs/demo-script.md
@@ -1,0 +1,256 @@
+# Team Demo — OTel Collector as Unified Ingestion Backbone
+
+A 20–25 minute walkthrough. Talking points on the left, commands to run on the
+right. Keep Grafana (http://localhost:3000) open in one tab and a Terminal
+window visible.
+
+Before starting:
+
+```bash
+# Make sure the demo is currently emitting telemetry — run this fresh
+# 60 seconds before the demo so trace data is current
+kubectl delete -f 06-validation/demo.yaml ; sleep 2
+kubectl apply -f 06-validation/demo.yaml
+```
+
+---
+
+## Part 1 — The problem we're solving (3 min)
+
+> *"Today every signal in our observability stack has its own ingestion path.
+> Metrics go through Prometheus scraping, logs go through Promtail, traces
+> come into Tempo via the OTel Collector, AWS metrics go through YACE, and
+> Kubernetes events aren't really collected at all. Five separate pipelines,
+> five places to configure metadata enrichment, redaction, and sampling.
+> When something breaks, we can't easily jump from a trace to its logs
+> because each tool labels pods differently."*
+
+Show the **before** diagram from `docs/architecture.md`.
+
+> *"The industry direction is clear — the OTel Collector becomes the single
+> ingestion backbone, every signal flows through it, and we get consistent
+> Kubernetes metadata across the board. This means: one place to redact
+> sensitive fields, one place to sample, and **cross-signal correlation
+> actually works** because every signal carries the same `service.name`,
+> `k8s.pod.name`, and `k8s.namespace.name` attributes."*
+
+---
+
+## Part 2 — What we deployed (5 min)
+
+Show the **after** diagram from `docs/architecture.md`.
+
+> *"We deployed the collector in two tiers, which is the standard pattern."*
+
+```bash
+kubectl -n observability get pods -l app.kubernetes.io/name=opentelemetry-collector
+```
+
+Point at the output:
+
+- **Agent (DaemonSet)** — one pod per node, runs everything that needs
+  node-local access (filesystem, kubelet API, host /proc and /sys).
+- **Gateway (Deployment)** — central pod, runs everything that's
+  cluster-wide (Kubernetes events, cluster-level metrics) plus cross-cutting
+  processing like tail sampling, redaction, and routing.
+
+```bash
+# Show what the agent collects locally
+kubectl -n observability exec ds/otel-agent-agent -- ls /var/log/pods | head
+```
+
+> *"That's `filelogreceiver` tailing real pod logs on disk. No Promtail.
+> Same collector also runs `hostmetricsreceiver` (CPU, memory, disk, network
+> from /proc) and `kubeletstatsreceiver` (per-pod CPU/memory from the
+> kubelet)."*
+
+```bash
+# Show the gateway receivers
+kubectl -n observability get cm otel-gateway -o yaml | grep -E "k8s_cluster|k8sobjects|otlp" | head -10
+```
+
+> *"The gateway has `k8s_cluster` (cluster-level resource metrics), `k8sobjects`
+> (Kubernetes events as log records), and the OTLP receiver where apps and
+> agents send everything else."*
+
+---
+
+## Part 3 — Show each signal flowing (8 min)
+
+### 3a. Traces
+
+Open Grafana → Explore → Tempo → Search → Service Name: `demo-app` → Run.
+
+> *"This is `demo-app`, our load generator. Each trace flows: app → agent's
+> OTLP receiver → gateway → Tempo. Click on any trace."*
+
+Click a trace, then click on the `okey-dokey-0` span.
+
+> *"Look at the Resource attributes panel — every span carries
+> `service.name`, `k8s.pod.name`, `k8s.namespace.name`, `k8s.node.name`.
+> Those were not in the app's code — they were added by the
+> `k8sattributes` processor in the collector pipeline."*
+
+### 3b. Logs
+
+Switch data source to Loki. Code mode. Paste:
+
+```
+{k8s_namespace_name="demo"}
+```
+
+> *"Same `k8s_namespace_name` label. These logs came from `filelogreceiver`
+> on the agent, with `k8sattributes` enrichment applied identically to how
+> it was applied to traces. Same processor, same pipeline pattern, same
+> labels."*
+
+### 3c. Kubernetes events
+
+In the same Loki view, paste:
+
+```
+{k8s_resource_name=~".+"}
+```
+
+> *"These are Kubernetes events — pod creates, container starts, schedule
+> decisions — coming in as log records from the gateway's `k8sobjects`
+> receiver. Previously we weren't collecting these at all. Now they're a
+> first-class signal in the same backend as application logs."*
+
+### 3d. Infrastructure metrics
+
+Switch data source to Prometheus. Paste:
+
+```
+system_cpu_load_average_1m
+```
+
+> *"Host metrics from the agent's `hostmetricsreceiver`."*
+
+```
+k8s_pod_cpu_usage{k8s_namespace_name="demo"}
+```
+
+> *"Per-pod metrics from `kubeletstatsreceiver`, filtered to our demo
+> namespace using the **same** `k8s_namespace_name` label that's on the
+> logs and traces."*
+
+```
+k8s_pod_phase
+```
+
+> *"Cluster-level state from `k8sclusterreceiver` on the gateway. None of
+> this needs Prometheus to scrape anything — it all flows OTLP → gateway
+> → `prometheusremotewrite` → Prometheus."*
+
+---
+
+## Part 4 — The payoff: cross-signal correlation (4 min)
+
+> *"The whole point of unifying ingestion: every signal carries the same
+> identifying labels, so we can pivot across them. Let me show you the
+> same pod three ways."*
+
+Pick one demo-logger pod name:
+
+```bash
+kubectl -n demo get pods -l app=demo-logger -o name
+```
+
+Copy the pod name (e.g. `demo-logger-xxxxx`). Then in Grafana:
+
+**Logs** — in Loki:
+
+```
+{k8s_namespace_name="demo", k8s_pod_name="demo-logger-xxxxx"}
+```
+
+**Metrics** — in Prometheus:
+
+```
+k8s_pod_cpu_usage{k8s_namespace_name="demo", k8s_pod_name="demo-logger-xxxxx"}
+```
+
+**Traces** — in Tempo Search → Service Name `demo-app` → Tags → `k8s.pod.name` = `demo-logger-xxxxx` (or the demo-traces pod).
+
+> *"Same `k8s_pod_name` label across all three. That's not magic — it's the
+> `k8sattributes` processor running identically on every pipeline. If we'd
+> have used five different collectors, getting consistent labeling would
+> have been a per-tool config exercise."*
+
+---
+
+## Part 5 — What's next (3 min)
+
+> *"What's in scope but we haven't done yet — and what we'd tackle next:"*
+
+1. **Migrate Prometheus scraping into the collector** — the `prometheusreceiver`
+   with a target-allocator lets the collector take over scrape jobs incrementally,
+   one ServiceMonitor at a time. The skeleton is in `07-prometheus-scrape-migration/`.
+
+2. **Decide YACE's fate.** Either keep YACE (simpler, writes to Prometheus
+   directly) or move CloudWatch into the collector via `awscloudwatchreceiver`
+   (unified config, same redaction pipeline, but heavier per-namespace
+   config). Both options are stubbed in `08-yace-decision/`.
+
+3. **Tail sampling & redaction** — the gateway is the natural place for both.
+   We'd add `tail_sampling` processor (drop healthy traces, keep errors) and
+   `transform` processor (redact PII fields) before exporters.
+
+4. **App SDK instrumentation** — out of scope for this work but the obvious
+   complement; once apps emit OTLP directly, we delete the Prometheus
+   scraping step entirely.
+
+> *"What's explicitly out of scope: replacing Prometheus with Mimir,
+> removing Grafana Beyla (keep it as an eBPF source feeding the same
+> collector), and the app SDK instrumentation."*
+
+---
+
+## Q&A preparation — likely questions and answers
+
+**"Why two tiers and not one?"**
+> Agent runs on every node so it can read local files and the kubelet API.
+> Gateway is cluster-wide so we have one place to do tail sampling, redaction,
+> and routing decisions — those things make no sense to do per-node.
+
+**"What if the gateway is down — do we lose telemetry?"**
+> Agent has a configurable send queue and retries. With persistent queue
+> enabled (`file_storage` extension), it survives gateway outages of minutes
+> to hours. The trade-off is disk on every node.
+
+**"How much overhead does the collector add?"**
+> In our lab, the agent runs ~50–100MB RAM per node and the gateway ~200MB
+> for our workload. The receivers + k8sattributes are the heaviest pieces.
+> In production we'd resource-cap aggressively and rely on tail sampling
+> to limit egress volume.
+
+**"Why OTLP into Loki and not the dedicated `loki` exporter?"**
+> The `loki` exporter was deprecated in favor of OTLP. Loki 3.x natively
+> ingests OTLP at `/otlp/v1/logs`, and uses the same attribute-to-label
+> rules across our whole pipeline. One protocol everywhere.
+
+**"What does this cost us to migrate?"**
+> Pure YAML/Helm work — no application code changes. Each signal type
+> migrates as a separate PR. Rollback is `helm rollback`. That's why we
+> can phase it (logs first, then metrics, then optionally Prom scraping).
+
+**"What if we want to add a new backend later — say, Datadog?"**
+> Add the exporter to the gateway. The receivers and processors don't
+> change. Vendor swap = config diff, not a re-platforming exercise. That's
+> the architectural value over the fragmented approach.
+
+---
+
+## Backup commands for "show me the YAML" moments
+
+```bash
+# Show the actual rendered collector config (the source of truth)
+kubectl -n observability get cm otel-gateway -o yaml | yq '.data."relay.yaml"'
+kubectl -n observability get cm otel-agent-agent -o yaml | yq '.data."relay.yaml"'
+
+# Verify what's actually been deployed
+helm -n observability list
+helm -n observability get values otel-gateway
+helm -n observability get values otel-agent
+```

--- a/app/robot-shop/robot-shop-local-values.yaml
+++ b/app/robot-shop/robot-shop-local-values.yaml
@@ -1,0 +1,90 @@
+# Robot Shop — local k3d override values
+# Fixes two blockers for the 4-node demo cluster:
+#   1. workload=persistent nodeSelector → no such node, redirect to workload=app
+#   2. replicas:3 + required podAntiAffinity → only 1 app node, reduce to 1 replica
+#
+# IMPORTANT: affinity: null (not {}) — Helm merges maps so {} leaves base affinity
+# unchanged. null explicitly deletes the key, clearing the podAntiAffinity.
+
+stack_mode: local
+
+# ── Persistent services: move to workload=app, drop persistent tolerations ──
+
+mongodb:
+  nodeSelector:
+    workload: app
+  tolerations: []
+
+mysql:
+  nodeSelector:
+    workload: app
+  tolerations: []
+
+redis:
+  nodeSelector:
+    workload: app
+  tolerations: []
+
+payment:
+  replicas: 1
+  nodeSelector:
+    workload: app
+  tolerations: []
+  affinity: null
+
+shipping:
+  replicas: 1
+  nodeSelector:
+    workload: app
+  tolerations: []
+  affinity: null
+  resources:
+    limits:
+      cpu: 300m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+rabbitmq:
+  nodeSelector:
+    workload: app
+  tolerations: []
+
+mysqlseeder:
+  nodeSelector:
+    workload: app
+  tolerations: []
+
+# ── App-tier services: replicas 3 → 1, remove required anti-affinity ──
+
+cart:
+  replicas: 1
+  affinity: null
+
+catalogue:
+  replicas: 1
+  affinity: null
+
+dispatch:
+  replicas: 1
+  affinity: null
+
+ratings:
+  replicas: 1
+  affinity: null
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+user:
+  replicas: 1
+  affinity: null
+
+web:
+  replicas: 1
+  affinity: null

--- a/demo-1-before.sh
+++ b/demo-1-before.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# demo-1-before.sh
+# Tear down any existing cluster and build the BEFORE state:
+#   k3d cluster (4 nodes) + Istio + Prometheus + Loki + Tempo
+#   + Robot Shop (with Istio sidecars) + HotROD
+#   NO OTel Collector.
+#
+# Run from: ~/Documents/Claude/Projects/sre-stack
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")"
+
+NS=monitoring
+
+log()     { echo; echo "══════════════════════════════════════════════════"; echo "▶  $*"; echo "══════════════════════════════════════════════════"; }
+log_sub() { echo "  ➜  $*"; }
+
+wait_for_pod() {
+  local label=$1 ns=${2:-$NS}
+  echo "  Waiting for pod matching '$label' in $ns..."
+  for i in $(seq 1 60); do
+    if kubectl get pods -n "$ns" 2>/dev/null | grep "$label" | grep -q "Running"; then
+      echo "  ✅ $label is Running"
+      return 0
+    fi
+    sleep 5
+  done
+  echo "  ⚠️  $label not ready after 300s — continuing anyway"
+}
+
+wait_for_job() {
+  local job=$1 ns=${2:-robot-shop}
+  echo "  Waiting for job '$job' in $ns..."
+  for i in $(seq 1 40); do
+    if kubectl get jobs -n "$ns" 2>/dev/null | grep "$job" | grep -q "1/1"; then
+      echo "  ✅ job $job complete"
+      return 0
+    fi
+    sleep 5
+  done
+  echo "  ⚠️  job $job not complete after 200s — continuing anyway"
+}
+
+# ─── 0. Nuke existing cluster ────────────────────────────────────────────────
+log "Step 0: Deleting existing cluster (if any)"
+k3d cluster delete sre-stack-local 2>/dev/null || true
+
+# ─── 1. Create k3d cluster ───────────────────────────────────────────────────
+log "Step 1: Creating k3d cluster (4 nodes)"
+k3d cluster create sre-stack-local \
+  --agents 3 \
+  --k3s-arg "--disable=traefik@server:*"
+
+# Node roles:
+#   agent-0, agent-1 → observability (tainted so only monitoring stack runs here)
+#   agent-2          → app workloads (Robot Shop + HotROD)
+kubectl label nodes k3d-sre-stack-local-agent-0 k3d-sre-stack-local-agent-1 workload=o11y
+kubectl taint nodes k3d-sre-stack-local-agent-0 k3d-sre-stack-local-agent-1 o11y=true:NoSchedule
+kubectl label nodes k3d-sre-stack-local-agent-2 workload=app
+
+# Raise inotify limits — prevents spurious pod restarts under heavy log load
+for node in agent-0 agent-1 agent-2 server-0; do
+  docker exec k3d-sre-stack-local-${node} \
+    sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288 2>/dev/null || true
+done
+
+kubectl apply -f ./infra/local/gp2-storageclass.yaml
+log_sub "Cluster ready"
+
+# ─── 2. Monitoring stack (no OTel) ───────────────────────────────────────────
+log "Step 2: Installing monitoring stack (Prometheus + Grafana + Loki + Tempo)"
+
+log_sub "kube-prometheus-stack"
+make setup-kube-prometheus-stack
+
+log_sub "Loki + Promtail (old stack — will be replaced in demo-2)"
+make setup-loki
+
+log_sub "Tempo"
+make setup-tempo
+
+log_sub "Zipkin service → bridges Istio traces to Tempo"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  namespace: monitoring
+spec:
+  selector:
+    app.kubernetes.io/name: tempo
+  ports:
+  - name: zipkin
+    port: 9411
+    targetPort: 9411
+EOF
+
+# ─── 3. Istio ────────────────────────────────────────────────────────────────
+log "Step 3: Installing Istio service mesh"
+make setup-istio
+
+log_sub "Applying Istio observability addons + dashboards"
+make setup-istio-o11y-addons
+make setup-dashboards
+
+# ─── 4. Robot Shop ───────────────────────────────────────────────────────────
+log "Step 4: Deploying Robot Shop (with Istio sidecar injection)"
+log_sub "Using local override values — single replica, all pods on workload=app node"
+echo
+echo "  Override file: app/robot-shop/robot-shop-local-values.yaml"
+echo "  Key overrides:"
+echo "    replicas: 1 (all services, avoids anti-affinity on single-node app tier)"
+echo "    nodeSelector: workload=app for all services (no persistent node in local cluster)"
+echo "    affinity: {} (removes required podAntiAffinity)"
+echo
+
+kubectl create namespace robot-shop --dry-run=client -o yaml | kubectl apply -f -
+
+# Enable Istio sidecar injection — this is what populates istio_requests_total
+# and makes the Application Dashboard / Service Map work
+kubectl label namespace robot-shop istio-injection=enabled --overwrite
+
+helm upgrade --install roboshop -n robot-shop --create-namespace \
+  ./app/robot-shop/helm/ \
+  --values ./app/robot-shop/robot-shop-local-values.yaml \
+  --set mysql_root_password=docdb3421z
+
+# Apply Istio gateway + virtual services for Robot Shop
+kubectl apply -f ./app/robot-shop/Istio/gateway.yaml -n robot-shop
+
+log_sub "Waiting for Robot Shop pods to start (MySQL + MongoDB take longest)..."
+sleep 20
+
+# Wait for key pods
+wait_for_pod "web" "robot-shop"
+wait_for_pod "catalogue" "robot-shop"
+wait_for_pod "user" "robot-shop"
+wait_for_pod "cart" "robot-shop"
+
+log_sub "Waiting for MySQL seeder job to complete..."
+wait_for_job "mysql-seeed" "robot-shop"
+
+echo
+kubectl get pods -n robot-shop
+echo
+
+# ─── 5. HotROD ───────────────────────────────────────────────────────────────
+log "Step 5: Deploying HotROD (traces via Jaeger endpoint — before OTel)"
+log_sub "HotROD namespace has NO Istio injection — it bypasses the mesh deliberately"
+make setup-hotrod
+sleep 10
+wait_for_pod "hotrod" "hotrod"
+
+# ─── 6. Port-forwards ────────────────────────────────────────────────────────
+log "Step 6: Starting port-forwards"
+
+pkill -f "port-forward svc/istio-ingressgateway" 2>/dev/null || true
+pkill -f "port-forward svc/hotrod"               2>/dev/null || true
+lsof -ti:8080,18080 | xargs kill -9 2>/dev/null  || true
+sleep 2
+
+# Single Istio port-forward handles both Grafana (/grafana) and Robot Shop (/)
+kubectl port-forward svc/istio-ingressgateway -n istio-system 8080:80 &
+kubectl port-forward svc/hotrod -n hotrod 18080:8080 &
+sleep 3
+
+# ─── 7. Warm up traffic ──────────────────────────────────────────────────────
+log "Step 7: Generating initial traffic to populate Istio metrics"
+log_sub "30 Robot Shop requests → istio_requests_total appears in Prometheus"
+echo
+
+for i in $(seq 1 30); do
+  curl -s http://localhost:8080/api/catalogue/categories  > /dev/null || true
+  curl -s http://localhost:8080/api/catalogue/products/1  > /dev/null || true
+  curl -s "http://localhost:8080/api/user/login" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"user","password":"password"}' > /dev/null || true
+  echo "  sent $i/30"
+  sleep 1
+done
+
+log_sub "5 HotROD requests (Jaeger-style traces, no app spans yet)"
+for i in $(seq 1 5); do
+  curl -s "http://localhost:18080/dispatch?customer=123&nonse=$RANDOM" > /dev/null || true
+  echo "  hotrod $i/5"
+  sleep 1
+done
+
+# ─── Done ────────────────────────────────────────────────────────────────────
+echo
+echo "╔══════════════════════════════════════════════════════════════════════╗"
+echo "║  BEFORE STATE IS READY                                              ║"
+echo "╠══════════════════════════════════════════════════════════════════════╣"
+echo "║  Grafana      →  http://localhost:8080/grafana                      ║"
+echo "║                  login: admin / prom-operator                       ║"
+echo "║  Robot Shop   →  http://localhost:8080                              ║"
+echo "║  HotROD       →  http://localhost:18080                             ║"
+echo "╠══════════════════════════════════════════════════════════════════════╣"
+echo "║  WHAT TO SHOW (before state — limitations):                         ║"
+echo "║                                                                      ║"
+echo "║  ✅ Application Dashboard → Istio service map for robot-shop        ║"
+echo "║     namespace visible, request rates from Istio sidecars            ║"
+echo "║                                                                      ║"
+echo "║  ❌ Explore → Prometheus → system_cpu_time_seconds_total            ║"
+echo "║     No results. Host CPU invisible (no OTel agent yet)              ║"
+echo "║                                                                      ║"
+echo "║  ❌ Explore → Prometheus → k8s_deployment_desired                   ║"
+echo "║     No results. k8s cluster state invisible (no OTel gateway yet)   ║"
+echo "║                                                                      ║"
+echo "║  ❌ Explore → Tempo → Search                                         ║"
+echo "║     Istio ingress hops only (1–2 spans). No app-level spans.        ║"
+echo "║     Cannot see Redis calls, DB calls, root cause of latency.        ║"
+echo "║                                                                      ║"
+echo "║  ❌ Explore → Loki → {namespace=\"robot-shop\"}                        ║"
+echo "║     Logs exist but NO trace_id field — cannot link log → trace      ║"
+echo "║                                                                      ║"
+echo "║  When done showing limitations, run:                                ║"
+echo "║    ./demo-2-migrate-otel.sh                                         ║"
+echo "╚══════════════════════════════════════════════════════════════════════╝"

--- a/demo-2-migrate-otel.sh
+++ b/demo-2-migrate-otel.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# demo-2-migrate-otel.sh
+#
+# Full OTel migration from the upstream infracloudio/sre-stack scope:
+#   • Two-tier OTel Collector (Agent DaemonSet + Gateway Deployment)
+#   • Loki 3.x switch (uninstall loki-stack → grafana/loki 7.0.0)
+#   • Logs:    filelog (agent) + k8sobjects (gateway) → otlphttp/loki → Loki 3.x
+#   • Metrics: hostmetrics+kubeletstats (agent) + k8s_cluster (gateway)
+#              → prometheusremotewrite → Prometheus
+#   • Traces:  app OTLP → agent → gateway → Tempo
+#   • Prometheus scraping: prometheusreceiver with kubernetes_sd_configs
+#   • k8sattributes processor on every pipeline for cross-signal correlation
+#
+# Prereq: demo-1-before.sh has run and the cluster is in the "before" state.
+# Do NOT add --wait or --timeout to helm commands — causes failures on MacBook Air.
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cd "$(dirname "$0")"
+
+NS=monitoring
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+log()          { echo; echo "══════════════════════════════════════════════════"; echo "▶  $*"; echo "══════════════════════════════════════════════════"; }
+log_sub()      { echo "  ➜  $*"; }
+
+wait_for_pod() {
+  local label=$1 ns=${2:-$NS}
+  echo "  Waiting for pod matching '$label' in $ns..."
+  for i in $(seq 1 40); do
+    if kubectl get pods -n "$ns" 2>/dev/null | grep "$label" | grep -q "Running"; then
+      echo "  ✅ $label is Running"
+      return 0
+    fi
+    sleep 5
+  done
+  echo "  ⚠️  $label not ready after 200s — continuing anyway"
+}
+
+wait_for_pod_gone() {
+  local label=$1 ns=${2:-$NS}
+  echo "  Waiting for '$label' to terminate in $ns..."
+  for i in $(seq 1 20); do
+    if ! kubectl get pods -n "$ns" 2>/dev/null | grep -q "$label"; then
+      echo "  ✅ $label is gone"
+      return 0
+    fi
+    sleep 3
+  done
+  echo "  ⚠️  $label still present after 60s — continuing"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 1 — Helm repos
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 1: Helm repo setup"
+helm repo add open-telemetry        https://open-telemetry.github.io/opentelemetry-helm-charts 2>/dev/null || true
+helm repo add grafana               https://grafana.github.io/helm-charts 2>/dev/null || true
+helm repo add prometheus-community  https://prometheus-community.github.io/helm-charts 2>/dev/null || true
+helm repo update
+log_sub "Repos ready"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 2 — Enable Prometheus remote_write receiver
+#
+# The OTel gateway ships metrics via prometheusremotewrite. Prometheus must
+# accept remote_write pushes via --web.enable-remote-write-receiver.
+# NOTE: prometheus-values.yaml already has enableRemoteWriteReceiver: true —
+# this step re-applies it at the pinned chart version to avoid schema drift.
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 2: Enabling Prometheus remote_write receiver"
+helm upgrade prometheus-stack prometheus-community/kube-prometheus-stack \
+  --namespace "$NS" \
+  --version 52.0.0 \
+  --reuse-values \
+  --set "prometheus.prometheusSpec.enableRemoteWriteReceiver=true"
+
+sleep 5
+wait_for_pod "prometheus-stack-kube-prom-prometheus"
+log_sub "Prometheus remote_write receiver enabled"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 3 — Switch from Loki 2.x (loki-stack) to Loki 3.x (grafana/loki)
+#
+# loki-stack 2.10.3 ships Loki 2.9.3 which has no OTLP ingest endpoint at all.
+# grafana/loki 7.0.0 ships Loki 3.6.7 with:
+#   - OTLP ingest at /otlp/v1/logs
+#   - allow_structured_metadata: true (stores OTel attrs alongside logs)
+#   - tsdb/v13 schema (required for Loki 3.x)
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 3: Switching to Loki 3.x (grafana/loki chart 7.0.0)"
+
+log_sub "Uninstalling loki-stack (removes Loki 2.x + Promtail)"
+helm uninstall loki --namespace "$NS" 2>/dev/null || true
+wait_for_pod_gone "promtail"
+
+log_sub "Installing grafana/loki 7.0.0 → Loki 3.6.7 (SingleBinary + PVC)"
+helm upgrade --install loki grafana/loki \
+  --namespace "$NS" \
+  --version 7.0.0 \
+  --values monitoring/chart-values/loki-v3-values.yaml
+
+sleep 10
+wait_for_pod "loki-0"
+kubectl get pods -n "$NS" | grep loki
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 4 — Deploy OTel Gateway (Deployment)
+#
+# Runs on o11y nodes. Receives OTLP from agents, enriches via k8sattributes.
+# Fans out:
+#   traces  → Tempo  (otlp/tempo  gRPC  :4317)
+#   metrics → Prometheus (prometheusremotewrite /api/v1/write)
+#   logs    → Loki 3.x (otlphttp/loki /otlp/v1/logs)
+#
+# Extra receivers on gateway only:
+#   k8s_cluster  → cluster-state metrics (deployment desired/ready, pod phases)
+#   k8sobjects   → k8s events as logs (CrashLoopBackOff, OOMKilled, etc.)
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 4: Deploying OTel Gateway (Deployment on o11y nodes)"
+echo "  Presets  : kubernetesAttributes | kubernetesEvents | clusterMetrics"
+echo "  Receivers: otlp | k8sobjects | k8s_cluster"
+echo "  Exporters: otlp/tempo | prometheusremotewrite/prom | otlphttp/loki"
+echo
+
+helm upgrade --install otel-gateway open-telemetry/opentelemetry-collector \
+  --namespace "$NS" \
+  --values monitoring/chart-values/otel-gateway-values.yaml
+
+sleep 5
+wait_for_pod "otel-gateway"
+kubectl get pods -n "$NS" | grep otel-gateway
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 5 — Deploy OTel Agent (DaemonSet)
+#
+# Runs on ALL nodes (tolerations: Exists — includes o11y-tainted nodes).
+# Collects node-level signals and forwards to gateway:
+#   filelog      → reads /var/log/pods/** (CRI format) — replaces Promtail
+#   hostmetrics  → CPU / memory / disk / network per node  [NEW metric coverage]
+#   kubeletstats → pod & container resource usage          [NEW metric coverage]
+#
+# k8sattributes preset stamps every record with pod/namespace/node/deployment.
+# kubeletstats override: insecure_skip_verify=true — k3d kubelet cert has no IP SANs.
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 5: Deploying OTel Agent DaemonSet (one pod per node)"
+echo "  Presets  : kubernetesAttributes | logsCollection | hostMetrics | kubeletMetrics"
+echo "  Receivers: filelog | hostmetrics | kubeletstats"
+echo "  Exporters: otlp → otel-gateway:4317"
+echo
+
+helm upgrade --install otel-agent open-telemetry/opentelemetry-collector \
+  --namespace "$NS" \
+  --values monitoring/chart-values/otel-agent-values.yaml
+
+sleep 5
+wait_for_pod "otel-agent"
+kubectl get pods -n "$NS" | grep otel
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 6 — Wire HotROD → OTel Gateway → Tempo
+#
+# Before : HotROD → Jaeger endpoint (Istio intercepts; only ingress hops in Tempo)
+# After  : HotROD → OTel Gateway:4318 (OTLP HTTP) → Tempo
+#          Each request creates 5+ spans: frontend / customer / driver / route / redis
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 6: Wiring HotROD → OTel Gateway → Tempo"
+echo "  Before: HotROD → JAEGER_ENDPOINT (only Istio ingress hops visible)"
+echo "  After : HotROD → OTEL_EXPORTER_OTLP_ENDPOINT=gateway:4318 (full app spans)"
+echo
+
+kubectl set env deployment/hotrod -n hotrod \
+  JAEGER_ENDPOINT- \
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-gateway.monitoring.svc.cluster.local:4318
+
+sleep 5
+wait_for_pod "hotrod" "hotrod"
+kubectl get pods -n hotrod
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 7 — Generate traffic (both apps)
+#
+# Robot Shop: HTTP through Istio ingress → populates istio_requests_total
+#             per service → Application Dashboard / Service Map works
+# HotROD:     dispatches → full app spans in Tempo with k8s attributes
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 7: Generating traffic — Robot Shop + HotROD"
+
+# Kill stale port-forward if HotROD pod restarted in Step 6
+pkill -f "port-forward svc/hotrod" 2>/dev/null || true
+lsof -ti:18080 | xargs kill -9 2>/dev/null || true
+sleep 2
+kubectl port-forward svc/hotrod -n hotrod 18080:8080 &
+sleep 3
+
+log_sub "Robot Shop — 40 requests across catalogue / user / cart"
+echo "  These flow through Istio sidecars → istio_requests_total per service"
+echo
+
+for i in $(seq 1 40); do
+  curl -s http://localhost:8080/api/catalogue/categories            > /dev/null || true
+  curl -s "http://localhost:8080/api/catalogue/products/1"         > /dev/null || true
+  curl -s "http://localhost:8080/api/catalogue/products/2"         > /dev/null || true
+  curl -s http://localhost:8080/api/user/login \
+    -H "Content-Type: application/json" \
+    -d '{"name":"user","password":"password"}'                     > /dev/null || true
+  curl -s http://localhost:8080/api/cart/items                     > /dev/null || true
+  echo "  robot-shop $i/40"
+  sleep 1
+done
+
+log_sub "HotROD — 20 requests (OTLP traces → Tempo with full app spans)"
+echo
+
+for i in $(seq 1 20); do
+  curl -s "http://localhost:18080/dispatch?customer=123&nonse=$(python3 -c 'import random; print(random.random())')" > /dev/null || true
+  echo "  hotrod $i/20"
+  sleep 1
+done
+
+log_sub "Waiting 25s for Tempo to flush trace blocks..."
+sleep 25
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STEP 8 — Enable Prometheus scraping via OTel Gateway
+#
+# Upgrades gateway to add a prometheusreceiver with kubernetes_sd_configs.
+# Scrapes two targets via endpoint discovery:
+#   - grafana            (metrics at /grafana/metrics)
+#   - prometheus-self    (metrics at /metrics)
+#
+# NOTE: Target Allocator (automatic ServiceMonitor discovery) is not used here
+# because the vanilla open-telemetry/opentelemetry-collector Helm chart does
+# not support the targetAllocator key — it requires the OTel Operator CRDs.
+# Direct scrape_configs achieves the same result for a known target set.
+# ─────────────────────────────────────────────────────────────────────────────
+log "Step 8: Enabling Prometheus scraping via OTel Gateway"
+echo "  Adding prometheusreceiver with kubernetes_sd_configs"
+echo "  Scrape targets: grafana + prometheus-self"
+echo "  Results pushed to Prometheus via remote_write"
+echo "  Job labels: monitoring/grafana, monitoring/prometheus-self"
+echo
+
+helm upgrade --install otel-gateway open-telemetry/opentelemetry-collector \
+  --namespace "$NS" \
+  --values monitoring/chart-values/otel-gateway-prom-scrape-values.yaml
+
+sleep 10
+wait_for_pod "otel-gateway"
+kubectl get pods -n "$NS" | grep otel-gateway
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Final state
+# ─────────────────────────────────────────────────────────────────────────────
+echo
+echo "╔══════════════════════════════════════════════════════════════════════╗"
+echo "║         OTel MIGRATION COMPLETE — VALIDATION GUIDE                  ║"
+echo "╠══════════════════════════════════════════════════════════════════════╣"
+echo "║                                                                      ║"
+echo "║  ACCESS                                                              ║"
+echo "║    Grafana    →  http://localhost:8080/grafana  (admin/prom-operator)║"
+echo "║    Robot Shop →  http://localhost:8080                               ║"
+echo "║    HotROD     →  http://localhost:18080                              ║"
+echo "║                                                                      ║"
+echo "║  APPLICATION DASHBOARDS (Robot Shop + Istio)                        ║"
+echo "║    Application Dashboard → Service Map populated (robot-shop ns)    ║"
+echo "║    Global Request Volume, per-service success/error rates visible    ║"
+echo "║    Istio metrics: istio_requests_total per source/destination        ║"
+echo "║                                                                      ║"
+echo "║  TRACES  Grafana → Explore → Tempo → Search                         ║"
+echo "║    HotROD spans: frontend / customer / driver / route / redis       ║"
+echo "║    Click span → k8s.pod.name, k8s.namespace.name on every span      ║"
+echo "║    Click 'Logs for this span' → jumps to correlated Loki logs       ║"
+echo "║                                                                      ║"
+echo "║  LOGS    Grafana → Explore → Loki                                   ║"
+echo "║    {k8s_namespace_name=\"hotrod\"} → logs enriched with OTel attrs    ║"
+echo "║    {k8s_namespace_name=\"robot-shop\"} → Robot Shop pod logs          ║"
+echo "║    {k8s_namespace_name=\"monitoring\"} → infra + collector logs       ║"
+echo "║                                                                      ║"
+echo "║  METRICS  Grafana → Explore → Prometheus                            ║"
+echo "║    system_cpu_time_seconds_total   → host metrics (OTel agent)      ║"
+echo "║    k8s_deployment_desired          → cluster state (OTel gateway)   ║"
+echo "║    container_cpu_usage_seconds_total → kubeletstats (OTel agent)    ║"
+echo "║    up{job=\"monitoring/grafana\"}     → OTel Prometheus scraping       ║"
+echo "║                                                                      ║"
+echo "║  CROSS-SIGNAL CORRELATION                                           ║"
+echo "║    Tempo: click span → 'Logs for this span' → Loki (same pod/time) ║"
+echo "║    Tempo: click span → 'Metrics for this span' → Prometheus         ║"
+echo "║    All signals share k8s attrs from k8sattributes processor         ║"
+echo "║                                                                      ║"
+echo "╠══════════════════════════════════════════════════════════════════════╣"
+echo "║  OTel Pods:"
+kubectl get pods -n monitoring | grep otel | awk '{printf "║    %-66s║\n", $1" "$3}'
+echo "║                                                                      ║"
+echo "║  Loki:"
+kubectl get pods -n monitoring | grep "^loki" | awk '{printf "║    %-66s║\n", $1" "$3}'
+echo "║                                                                      ║"
+echo "║  Robot Shop:"
+kubectl get pods -n robot-shop | grep -v NAME | awk '{printf "║    %-66s║\n", $1" "$3}'
+echo "╚══════════════════════════════════════════════════════════════════════╝"

--- a/monitoring/chart-values/loki-v3-values.yaml
+++ b/monitoring/chart-values/loki-v3-values.yaml
@@ -1,0 +1,70 @@
+# Loki 3.x — SingleBinary mode for k3d sre-stack-local cluster
+# Adapted from OTel/02-lgtm-stack/loki-values.yaml (upstream uses observability ns)
+# Key differences vs upstream: resource limits reduced for MacBook Air,
+# tolerations added for o11y nodes.
+deploymentMode: SingleBinary
+
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: filesystem
+  # schemaConfig (camelCase) is the Helm chart key — maps to schema_config in Loki config.
+  # Required by chart validator; useTestSchema is NOT used.
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+  # OTLP push endpoint at /otlp/v1/logs enabled by default in Loki 3.x.
+  # allow_structured_metadata required for OTel resource attributes.
+  limits_config:
+    allow_structured_metadata: true
+    volume_enabled: true
+
+singleBinary:
+  replicas: 1
+  nodeSelector:
+    workload: o11y
+  tolerations:
+    - key: o11y
+      value: "true"
+      effect: NoSchedule
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+  # PVC via k3d local-path provisioner — gives Loki a writable /var/loki
+  persistence:
+    enabled: true
+    size: 2Gi
+
+# Disable distributed-mode components
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+
+# Disable optional dependencies
+gateway:
+  enabled: false
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+minio:
+  enabled: false
+test:
+  enabled: false
+lokiCanary:
+  enabled: false

--- a/monitoring/chart-values/otel-agent-values.yaml
+++ b/monitoring/chart-values/otel-agent-values.yaml
@@ -1,0 +1,88 @@
+# OTel Collector — AGENT tier (DaemonSet, one pod per node)
+# Adapted for k3d sre-stack-local cluster, monitoring namespace.
+# Step 05: adds hostMetrics + kubeletMetrics presets on top of step 04.
+#
+# No nodeSelector — must run on ALL nodes to collect host signals.
+mode: daemonset
+fullnameOverride: otel-agent
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+    extractAllPodAnnotations: false
+  logsCollection:
+    enabled: true
+    includeCollectorLogs: false
+    storeCheckpoints: true
+  # Node-level CPU/mem/disk/network metrics
+  hostMetrics:
+    enabled: true
+  # Pod/container resource usage from kubelet
+  kubeletMetrics:
+    enabled: true
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 400Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+tolerations:
+  - operator: Exists
+    effect: NoSchedule
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    # hostmetrics injected by preset
+    # Override kubeletstats: k3d kubelet cert has no IP SANs
+    kubeletstats:
+      collection_interval: 20s
+      auth_type: serviceAccount
+      endpoint: ${env:OTEL_K8S_NODE_IP}:10250
+      insecure_skip_verify: true
+      metric_groups:
+        - node
+        - pod
+        - container
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+
+  exporters:
+    otlp/gateway:
+      endpoint: otel-gateway.monitoring.svc:4317
+      tls:
+        insecure: true
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      metrics:
+        receivers: [otlp, hostmetrics, kubeletstats]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]
+      logs:
+        receivers: [otlp, filelog]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/gateway]

--- a/monitoring/chart-values/otel-gateway-prom-scrape-values.yaml
+++ b/monitoring/chart-values/otel-gateway-prom-scrape-values.yaml
@@ -1,0 +1,187 @@
+# OTel Collector — GATEWAY tier with Prometheus scraping (Step 07)
+#
+# NOTE: the vanilla open-telemetry/opentelemetry-collector Helm chart does NOT
+# support a top-level `targetAllocator` key in its values schema (confirmed —
+# rejected under both "deployment" and "statefulset" modes). Target Allocator
+# + ServiceMonitor/PodMonitor CRD auto-discovery is only available when the
+# collector is deployed via the OpenTelemetry *Operator*'s OpenTelemetryCollector
+# CRD — a separate, heavier deployment model.
+#
+# For this scope we replicate the same outcome with direct scrape_configs in
+# the prometheusreceiver, targeting the exact endpoints two real ServiceMonitors
+# already cover in this cluster (verified via `kubectl get servicemonitors -A`):
+#   prometheus-stack-grafana               → port http-web, path /metrics
+#   prometheus-stack-kube-prom-prometheus  → ports http-web + reloader-web, path /metrics
+# This is the documented incremental path: "start with a couple of
+# ServiceMonitors" — functionally equivalent to CRD discovery for a small,
+# known target set. (kube-state-metrics / node-exporter are NOT deployed in
+# this cluster — confirmed via `kubectl get svc -n monitoring` — so they were
+# dropped in favor of these two, which actually exist.)
+mode: deployment
+replicaCount: 1
+fullnameOverride: otel-gateway
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+  kubernetesEvents:
+    enabled: true
+  clusterMetrics:
+    enabled: true
+
+# The presets above grant RBAC for pods/namespaces/nodes/etc, but NOT for
+# endpoints/services — required by the prometheusreceiver's
+# kubernetes_sd_configs (role: endpoints) to discover scrape targets.
+# Confirmed missing via: "endpoints is forbidden" in collector logs.
+clusterRole:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: ["endpoints", "services"]
+      verbs: ["get", "list", "watch"]
+
+service:
+  type: ClusterIP
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    protocol: TCP
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
+
+nodeSelector:
+  workload: o11y
+
+tolerations:
+  - key: o11y
+    value: "true"
+    effect: NoSchedule
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc: { endpoint: 0.0.0.0:4317 }
+        http: { endpoint: 0.0.0.0:4318 }
+    # Direct scrape configs replicating two real ServiceMonitors already in
+    # this cluster — the "couple of ServiceMonitors" incremental migration
+    # step, without CRD discovery (see header note on why no Target Allocator).
+    prometheus:
+      config:
+        scrape_configs:
+          # Mirrors ServiceMonitor: prometheus-stack-grafana
+          # Grafana serves metrics under /grafana/metrics (301 redirect from
+          # /metrics — confirmed via curl). Scrapers don't follow redirects,
+          # so the path must be set explicitly.
+          - job_name: 'grafana'
+            scrape_interval: 30s
+            metrics_path: /grafana/metrics
+            kubernetes_sd_configs:
+              - role: endpoints
+                namespaces:
+                  names: ['monitoring']
+            relabel_configs:
+              - source_labels: [__meta_kubernetes_service_name]
+                action: keep
+                regex: prometheus-stack-grafana
+              - source_labels: [__meta_kubernetes_endpoint_port_name]
+                action: keep
+                regex: http-web
+              - source_labels: [__meta_kubernetes_namespace]
+                target_label: namespace
+              - source_labels: [__meta_kubernetes_service_name]
+                target_label: service
+          # Mirrors ServiceMonitor: prometheus-stack-kube-prom-prometheus
+          - job_name: 'prometheus-self'
+            scrape_interval: 30s
+            kubernetes_sd_configs:
+              - role: endpoints
+                namespaces:
+                  names: ['monitoring']
+            relabel_configs:
+              - source_labels: [__meta_kubernetes_service_name]
+                action: keep
+                regex: prometheus-stack-kube-prom-prometheus
+              - source_labels: [__meta_kubernetes_endpoint_port_name]
+                action: keep
+                regex: http-web|reloader-web
+              - source_labels: [__meta_kubernetes_namespace]
+                target_label: namespace
+              - source_labels: [__meta_kubernetes_service_name]
+                target_label: service
+    # k8sobjects + k8s_cluster injected by presets
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+    resource/app-label:
+      attributes:
+        - action: insert
+          key: app
+          from_attribute: k8s.pod.labels.service
+        - action: upsert
+          key: app
+          from_attribute: k8s.pod.labels.app
+    resource/loki-labels:
+      attributes:
+        - action: insert
+          key: loki.resource.labels
+          value: service.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,app
+
+  exporters:
+    otlp/tempo:
+      endpoint: tempo.monitoring.svc:4317
+      tls: { insecure: true }
+    otlphttp/loki:
+      endpoint: http://loki.monitoring.svc:3100/otlp
+      tls: { insecure: true }
+    prometheusremotewrite/prom:
+      endpoint: http://prometheus-stack-kube-prom-prometheus.monitoring.svc:9090/api/v1/write
+      tls: { insecure: true }
+      resource_to_telemetry_conversion:
+        enabled: true
+    debug:
+      verbosity: basic
+
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/tempo]
+      # Both OTLP-pushed app metrics AND scraped metrics share one pipeline.
+      metrics:
+        receivers: [otlp, prometheus]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      metrics/cluster:
+        receivers: [k8s_cluster]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      logs:
+        receivers: [otlp, k8sobjects]
+        processors: [memory_limiter, k8sattributes, resource/app-label, resource/loki-labels, batch]
+        exporters: [otlphttp/loki, debug]

--- a/monitoring/chart-values/otel-gateway-values.yaml
+++ b/monitoring/chart-values/otel-gateway-values.yaml
@@ -1,0 +1,148 @@
+# OTel Collector — GATEWAY tier (Deployment, cluster-wide aggregation)
+# Adapted from OTel/05-metrics-migration/gateway-values.yaml
+# Namespace: monitoring (not observability)
+# Service endpoints adapted to sre-stack-local service names.
+mode: deployment
+replicaCount: 1
+fullnameOverride: otel-gateway
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+presets:
+  # Enriches every span/metric/log with k8s.pod.name, k8s.namespace.name,
+  # k8s.node.name, plus all pod labels — THE key differentiator vs Promtail.
+  kubernetesAttributes:
+    enabled: true
+    extractAllPodLabels: true
+  # Kubernetes events ingested as log records → Loki
+  kubernetesEvents:
+    enabled: true
+  # k8s_cluster receiver: pod phases, deployment replicas, node conditions
+  # Replaces kube-state-metrics for cluster-state visibility.
+  clusterMetrics:
+    enabled: true
+
+service:
+  type: ClusterIP
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    protocol: TCP
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 300m
+    memory: 512Mi
+
+nodeSelector:
+  workload: o11y
+
+tolerations:
+  - key: o11y
+    value: "true"
+    effect: NoSchedule
+
+config:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    # k8sobjects + k8s_cluster injected by presets above
+
+  processors:
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+    batch:
+      send_batch_size: 1024
+      timeout: 5s
+    # Synthesise an `app` resource attribute so Loki stream labels match the
+    # dashboard queries ({app="web"}, {app="ratings"}, etc.).
+    #
+    # Robot Shop pods use `service: web` (not `app`).  Other pods (HotROD,
+    # monitoring) use the conventional `app` pod label.  Strategy:
+    #   1. insert from k8s.pod.labels.service  — sets `app` for Robot Shop pods
+    #      (insert is a no-op when `app` already exists)
+    #   2. upsert from k8s.pod.labels.app      — overrides with the `app` pod
+    #      label when present (HotROD etc.); no-op when the attribute is absent
+    resource/app-label:
+      attributes:
+        - action: insert
+          key: app
+          from_attribute: k8s.pod.labels.service
+        - action: upsert
+          key: app
+          from_attribute: k8s.pod.labels.app
+    # Promote key OTel resource attributes → Loki stream labels.
+    # Without this Loki 3.x OTLP receives logs but has nothing to index on.
+    # `app` added here so {app="web"} queries in the Application Dashboard work.
+    resource/loki-labels:
+      attributes:
+        - action: insert
+          key: loki.resource.labels
+          value: service.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,app
+
+  exporters:
+    # Traces → Tempo (OTLP gRPC)
+    otlp/tempo:
+      endpoint: tempo.monitoring.svc:4317
+      tls:
+        insecure: true
+    # Metrics → Prometheus (remote_write)
+    # resource_to_telemetry_conversion promotes OTel resource attrs to Prom labels
+    # so k8s.namespace.name, k8s.pod.name etc appear on every metric series.
+    prometheusremotewrite/prom:
+      endpoint: http://prometheus-stack-kube-prom-prometheus.monitoring.svc:9090/api/v1/write
+      tls:
+        insecure: true
+      resource_to_telemetry_conversion:
+        enabled: true
+    # Logs → Loki 3.x via OTLP HTTP (/otlp/v1/logs endpoint)
+    # Replaces the deprecated loki exporter and Promtail.
+    otlphttp/loki:
+      endpoint: http://loki.monitoring.svc:3100/otlp
+      tls:
+        insecure: true
+    debug:
+      verbosity: basic
+
+  service:
+    pipelines:
+      # App traces: OTel SDK → agent → gateway → Tempo
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [otlp/tempo]
+      # App metrics pushed via OTLP → gateway → Prometheus
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      # Cluster-state metrics from k8s_cluster receiver → Prometheus
+      # Replaces kube-state-metrics. Same Prometheus, same dashboards.
+      metrics/cluster:
+        receivers: [k8s_cluster]
+        processors: [memory_limiter, k8sattributes, batch]
+        exporters: [prometheusremotewrite/prom]
+      # Pod logs (via agents filelog) + k8s events → Loki
+      # resource/loki-labels runs before batch so labels are set before export.
+      logs:
+        receivers: [otlp, k8sobjects]
+        processors: [memory_limiter, k8sattributes, resource/app-label, resource/loki-labels, batch]
+        exporters: [otlphttp/loki, debug]

--- a/monitoring/dashboards/application.yaml
+++ b/monitoring/dashboards/application.yaml
@@ -1107,7 +1107,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"web\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"web-.*\"} |~ `(?i)error` [1m]))",
             "legendFormat": "{{web}}",
             "queryType": "range",
             "refId": "A"
@@ -1118,7 +1118,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"catalogue\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"catalogue-.*\"} |~ `(?i)error` [1m]))",
             "hide": false,
             "legendFormat": "{{catalogue}}",
             "queryType": "range",
@@ -1130,7 +1130,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"user\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"user-.*\"} |~ `(?i)error` [1m]))",
             "hide": false,
             "queryType": "range",
             "refId": "C"
@@ -1141,7 +1141,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"cart\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"cart-.*\"} |~ `(?i)error` [1m]))",
             "hide": false,
             "queryType": "range",
             "refId": "D"
@@ -1152,7 +1152,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"payment\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"payment-.*\"} |~ `(?i)error` [1m]))",
             "hide": false,
             "legendFormat": "{{payment}}",
             "queryType": "range",
@@ -1164,7 +1164,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"dispatch\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"dispatch-.*\"} |~ `(?i)error` [1m]))",
             "hide": false,
             "legendFormat": "{{dispatch}}",
             "queryType": "range",
@@ -1176,7 +1176,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"shipping\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"shipping-.*\"} |~ `(?i)error` [1m]))",
             "hide": false,
             "legendFormat": "{{shipping}}",
             "queryType": "range",
@@ -1188,7 +1188,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "sum(rate({app=\"ratings\"} |~ `(?i)error` [1m]))",
+            "expr": "sum(rate({k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"ratings-.*\"} |~ `(?i)error` [1m]))",
             "hide": false,
             "legendFormat": "{{ratings}}",
             "queryType": "range",
@@ -1228,7 +1228,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"web\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"web-.*\"} |~ `(?i)error`",
             "hide": false,
             "queryType": "range",
             "refId": "A"
@@ -1266,7 +1266,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"ratings\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"ratings-.*\"} |~ `(?i)error`",
             "hide": false,
             "queryType": "range",
             "refId": "A"
@@ -1402,7 +1402,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"dispatch\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"dispatch-.*\"} |~ `(?i)error`",
             "queryType": "range",
             "refId": "A"
           }
@@ -1439,7 +1439,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"shipping\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"shipping-.*\"} |~ `(?i)error`",
             "queryType": "range",
             "refId": "A"
           }
@@ -1572,7 +1572,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"cart\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"cart-.*\"} |~ `(?i)error`",
             "queryType": "range",
             "refId": "A"
           }
@@ -1609,7 +1609,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"catalogue\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"catalogue-.*\"} |~ `(?i)error`",
             "queryType": "range",
             "refId": "A"
           }
@@ -1646,7 +1646,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"payment\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"payment-.*\"} |~ `(?i)error`",
             "queryType": "range",
             "refId": "A"
           }
@@ -1683,7 +1683,7 @@ data:
               "uid": "${lokidatasource}"
             },
             "editorMode": "builder",
-            "expr": "{app=\"user\"} |~ `(?i)error`",
+            "expr": "{k8s_namespace_name=\"robot-shop\", k8s_pod_name=~\"user-.*\"} |~ `(?i)error`",
             "queryType": "range",
             "refId": "A"
           }


### PR DESCRIPTION
full OTel migration: two-tier collector, Loki 3.x, demo scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a step-by-step local observability lab flow for macOS/kind, including cluster setup, monitoring stack install, OpenTelemetry collection, migrations, and validation.
  * Added demo workloads and helper scripts to generate traces, logs, metrics, and Kubernetes events for end-to-end testing.
  * Added new dashboard and routing updates so log and error panels align with Kubernetes-aware labels.

* **Documentation**
  * Added comprehensive guides for the migration path, architecture, demo script, and optional CloudWatch/YACE decision points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->